### PR TITLE
ci(update-doc.yml)/disable package global dependencies installation for doc generation

### DIFF
--- a/.github/workflows/update-doc.yml
+++ b/.github/workflows/update-doc.yml
@@ -1,3 +1,4 @@
+
 ---
 name: Update Documentation
 
@@ -19,8 +20,11 @@ jobs:
 
       - name: Install doc dependecies 
         run: |
-          echo "Installing doc dependencies"
-          pip install -e .[doc]
+          pip install --upgrade pip
+          pip install tomlq
+          PIP_DOC_PACKAGE=$(tomlq -r '.project."optional-dependencies".doc | join(" ")' pyproject.toml)
+          echo "Installing doc dependencies : $PIP_DOC_PACKAGE"
+          pip install $PIP_DOC_PACKAGE
 
       - name: Deploy MkDocs to GitHub Pages
         run: |

--- a/docs/contributing/fork.md
+++ b/docs/contributing/fork.md
@@ -2,7 +2,7 @@
 
 When working with a fork, follow these steps to set up your local development environment:
 
-If you need help with git, have a look at the [Git QuickSheet](./git-guicksheet.md).
+If you need help with git, have a look at the [Git QuickSheet](./git-quicksheet.md).
 
 
 ---


### PR DESCRIPTION
pip always install all the dependencies the section of pyproject.toml, but cuda is not needed to deploy doc. ad commands that are reding the optional-dependencies".doc in the file, and use standard  pip call
