### PR TITLE
Refactor/gradmodel

### DIFF
--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -287,7 +287,6 @@ class GradSolver(nn.Module):
 
     """
 
-
     def __init__(
         self,
         grad_mod,
@@ -319,18 +318,14 @@ class GradSolver(nn.Module):
         self.obs_cost = obs_cost
         self.grad_mod = grad_mod
 
-
         self.n_step = n_step
         self.lr_grad = lr_grad
         self.lbd = lbd
 
-
         self.input_grad_update = input_grad_update
         self.std_init = std_init
 
-
         self._grad_norm = None
-
 
     def init_state(self, batch, x_init=None):
         """
@@ -348,13 +343,11 @@ class GradSolver(nn.Module):
         if x_init is not None:
             return x_init.detach().requires_grad_(True)
 
-
         if self.std_init > 0:
             x0 = self.std_init * torch.randn_like(batch.input)
             return x0.detach().requires_grad_(True)
         else:
             return torch.zeros_like(batch.input).detach().requires_grad_(True)
-
 
     def init_h_state(self, batch, h_state=None):
         """
@@ -374,15 +367,12 @@ class GradSolver(nn.Module):
         else:
             self.h_state = torch.zeros_like(batch.input).detach().requires_grad_(True)
 
-
     def format2D_3D(self, x):
         if hasattr(self.grad_mod, "dim_3d"):
             if self.grad_mod.dim_3d:
                 x = x.unsqueeze(1)
 
-
         return x
-
 
     def solver_step(self, state, batch, step, alpha_step=1.0):
         """
@@ -399,30 +389,22 @@ class GradSolver(nn.Module):
             torch.Tensor: Updated state.
         """
 
-
         if isinstance(step, float):
             t = torch.tensor([step], device=state.device).repeat(state.shape[0])
         else:
             t = step
 
-
         if "subgrad" in self.input_grad_update:
             gobs = (batch.input - state).nan_to_num()
 
-
             gprior = state - self.prior_cost.forward_ae(state)
-            grad = torch.concatenate(
-                (self.format2D_3D(gobs), self.format2D_3D(gprior)), dim=1
-            )
-
+            grad = torch.concatenate((self.format2D_3D(gobs), self.format2D_3D(gprior)), dim=1)
 
             if "state" in self.input_grad_update:
                 grad = torch.concatenate((grad, self.format2D_3D(state)), dim=1)
 
-
             if "previous" in self.input_grad_update:
                 grad = torch.concatenate((grad, self.format2D_3D(self.h_state)), dim=1)
-
 
         elif "gradsplit" in self.input_grad_update:
             prior_cost = self.prior_cost(state)
@@ -435,26 +417,19 @@ class GradSolver(nn.Module):
                 grad = grad / ((grad**2).mean().sqrt().detach())
                 grad = torch.concatenate((grad, state), dim=1)
 
-
         elif "grad" in self.input_grad_update:
-            var_cost = self.prior_cost(state) + self.lbd**2 * self.obs_cost(
-                state, batch
-            )
+            var_cost = self.prior_cost(state) + self.lbd**2 * self.obs_cost(state, batch)
             grad = torch.autograd.grad(var_cost, state, create_graph=True)[0]
-
 
             if "state" in self.input_grad_update:
                 grad = grad / ((grad**2).mean().sqrt().detach())
                 grad = torch.concatenate((grad, self.format2D_3D(state)), dim=1)
 
-
             if "previous" in self.input_grad_update:
                 grad = torch.concatenate((grad, self.format2D_3D(self.h_state)), dim=1)
 
-
         elif self.input_grad_update == "obs-only":
             grad = batch.input.nan_to_num()
-
 
         elif self.input_grad_update == "obs+state":
             grad = torch.concatenate(
@@ -462,28 +437,18 @@ class GradSolver(nn.Module):
                 dim=1,
             )
 
-
         gmod = self.grad_mod(grad, timesteps=t, extra=None)
         if hasattr(self.grad_mod, "dim_3d"):
             if self.grad_mod.dim_3d:
                 gmod = gmod.squeeze(1)
 
-
         state_update = alpha_step * gmod
         if ("grad" in self.input_grad_update) and (self.lr_grad > 0.0):
-            state_update += (
-                self.lr_grad
-                * (step + 1)
-                / self.n_step
-                * grad[:, : state.shape[1], :, :]
-            )
-
+            state_update += self.lr_grad * (step + 1) / self.n_step * grad[:, : state.shape[1], :, :]
 
         self.h_state = state_update
 
-
         return state - state_update
-
 
     def forward(self, batch, x_init=None, h_state=None, phase="test"):
         """
@@ -502,24 +467,19 @@ class GradSolver(nn.Module):
             self.init_h_state(batch, h_state=h_state)
             self.grad_mod.reset_state(batch.input)
 
-
             if not self.training:
-                if ("subgrad" in self.input_grad_update) or (
-                    "grad" not in self.input_grad_update
-                ):
+                if ("subgrad" in self.input_grad_update) or ("grad" not in self.input_grad_update):
                     state.requires_grad_(False)
                     self.h_state.requires_grad_(False)
 
-
             for step in range(self.n_step):
                 alpha_step = 1.0 / self.n_step
-                state = self.solver_step(state, batch, step=step/self.n_step, alpha_step=alpha_step)
+                state = self.solver_step(state, batch, step=step / self.n_step, alpha_step=alpha_step)
                 if (not self.training) and ("grad" in self.input_grad_update):
                     if "subgrad" in self.input_grad_update:
                         state = state.detach().requires_grad_(False)
                     else:
                         state = state.detach().requires_grad_(True)
-
 
         return state
 
@@ -674,7 +634,6 @@ class ConvLstmGradModel(nn.Module):
         out = self.conv_out(hidden)
         out = self.up(out)
         return out
-
 
 
 # ===================================================

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -617,7 +617,7 @@ class ConvLstmGradModel(nn.Module):
         up (nn.Module): Upsampling layer.
     """
 
-    def __init__(self, dim_in, dim_hidden, kernel_size=3, dropout=0.1, downsamp=None):
+    def __init__(self, dim_in, dim_out, dim_hidden, kernel_size=3, dropout=0.1, downsamp=None):
         """
         Initialize the ConvLstmGradModel.
 
@@ -637,7 +637,7 @@ class ConvLstmGradModel(nn.Module):
             padding=kernel_size // 2,
         )
 
-        self.conv_out = torch.nn.Conv2d(dim_hidden, dim_in, kernel_size=kernel_size, padding=kernel_size // 2)
+        self.conv_out = torch.nn.Conv2d(dim_hidden, dim_out, kernel_size=kernel_size, padding=kernel_size // 2)
 
         self.dropout = torch.nn.Dropout(dropout)
         self._state = []

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -21,9 +21,10 @@ from torch import nn
 import torch.nn.functional as F
 from typing import Optional
 
+
 # ===================================================
 # Lightning Modules
-# ====================================================
+# ===================================================
 
 class LitModel(pl.LightningModule):
     """
@@ -267,14 +268,13 @@ class Lit4dVarNet(LitModel):
         return base_loss + 1.0 * prior_cost
 
 
-#===================================================
+# ===================================================
 # Solvers
-# ====================================================
+# ===================================================
 
 class GradSolver(nn.Module):
     """
     A gradient-based solver for optimization in unrolled architectures.
-
 
     Attributes:
         prior_cost (nn.Module, optional): The prior cost function.
@@ -283,7 +283,6 @@ class GradSolver(nn.Module):
         n_step (int): Number of optimization steps.
         lr_grad (float): Learning rate for gradient updates.
         lbd (float): Regularization parameter.
-
 
     """
 
@@ -301,7 +300,6 @@ class GradSolver(nn.Module):
     ):
         """
         Initialize the GradSolver.
-
 
         Args:
             prior_cost (nn.Module): The prior cost function.
@@ -331,11 +329,9 @@ class GradSolver(nn.Module):
         """
         Initialize the state for optimization.
 
-
         Args:
             batch (dict): Input batch containing data.
             x_init (torch.Tensor, optional): Initial state. Defaults to None.
-
 
         Returns:
             torch.Tensor: Initialized state.
@@ -353,11 +349,9 @@ class GradSolver(nn.Module):
         """
         Initialize the state for optimization.
 
-
         Args:
             batch (dict): Input batch containing data.
             x_init (torch.Tensor, optional): Initial state. Defaults to None.
-
 
         Returns:
             torch.Tensor: Initialized state.
@@ -378,12 +372,10 @@ class GradSolver(nn.Module):
         """
         Perform a single optimization step.
 
-
         Args:
             state (torch.Tensor): Current state.
             batch (dict): Input batch containing data.
             step (int): Current optimization step between 0 and 1.
-
 
         Returns:
             torch.Tensor: Updated state.
@@ -454,10 +446,8 @@ class GradSolver(nn.Module):
         """
         Perform the forward pass of the solver.
 
-
         Args:
             batch (dict): Input batch containing data.
-
 
         Returns:
             torch.Tensor: Final optimized state.
@@ -484,10 +474,9 @@ class GradSolver(nn.Module):
         return state
 
 
-#===================================================
+# ===================================================
 # Modeles (UNET, ConvLSTM)
-# ====================================================
-
+# ===================================================
 
 class GradModelWithCondition(torch.nn.Module):
     """
@@ -638,8 +627,7 @@ class ConvLstmGradModel(nn.Module):
 
 # ===================================================
 # Observation Cost and Prior Cost
-# ====================================================
-
+# ===================================================
 
 class BaseObsCost(nn.Module):
     """

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -19,7 +19,7 @@ import kornia.filters as kfilts
 import torch
 from torch import nn
 import torch.nn.functional as F
-
+from typing import Optional
 
 # ===================================================
 # Lightning Modules
@@ -273,20 +273,36 @@ class Lit4dVarNet(LitModel):
 
 class GradSolver(nn.Module):
     """
-    A gradient-based solver for optimization in 4D-VarNet.
+    A gradient-based solver for optimization in unrolled architectures.
+
 
     Attributes:
-        prior_cost (nn.Module): The prior cost function.
-        obs_cost (nn.Module): The observation cost function.
+        prior_cost (nn.Module, optional): The prior cost function.
+        obs_cost (nn.Module, optional): The observation cost function.
         grad_mod (nn.Module): The gradient modulation model.
         n_step (int): Number of optimization steps.
         lr_grad (float): Learning rate for gradient updates.
         lbd (float): Regularization parameter.
+
+
     """
 
-    def __init__(self, prior_cost, obs_cost, grad_mod, n_step, lr_grad=0.2, lbd=1.0, **kwargs):
+
+    def __init__(
+        self,
+        grad_mod,
+        n_step,
+        lr_grad=0.2,
+        lbd=1.0,
+        input_grad_update="state",
+        std_init=0.1,
+        prior_cost: Optional[nn.Module] = None,
+        obs_cost: Optional[nn.Module] = None,
+        **kwargs,
+    ):
         """
         Initialize the GradSolver.
+
 
         Args:
             prior_cost (nn.Module): The prior cost function.
@@ -295,75 +311,216 @@ class GradSolver(nn.Module):
             n_step (int): Number of optimization steps.
             lr_grad (float, optional): Learning rate for gradient updates. Defaults to 0.2.
             lbd (float, optional): Regularization parameter. Defaults to 1.0.
+            input_grad_update (str, optional): Quantities added for updating the input gradient. Defaults to "state".
+            std_init (float, optional): Standard deviation for initializing the state. Defaults to 0.1.
         """
         super().__init__()
         self.prior_cost = prior_cost
         self.obs_cost = obs_cost
         self.grad_mod = grad_mod
 
+
         self.n_step = n_step
         self.lr_grad = lr_grad
         self.lbd = lbd
 
+
+        self.input_grad_update = input_grad_update
+        self.std_init = std_init
+
+
         self._grad_norm = None
+
 
     def init_state(self, batch, x_init=None):
         """
         Initialize the state for optimization.
 
+
         Args:
             batch (dict): Input batch containing data.
             x_init (torch.Tensor, optional): Initial state. Defaults to None.
+
 
         Returns:
             torch.Tensor: Initialized state.
         """
         if x_init is not None:
-            return x_init
+            return x_init.detach().requires_grad_(True)
 
-        return batch.input.nan_to_num().detach().requires_grad_(True)
 
-    def solver_step(self, state, batch, step):
+        if self.std_init > 0:
+            x0 = self.std_init * torch.randn_like(batch.input)
+            return x0.detach().requires_grad_(True)
+        else:
+            return torch.zeros_like(batch.input).detach().requires_grad_(True)
+
+
+    def init_h_state(self, batch, h_state=None):
+        """
+        Initialize the state for optimization.
+
+
+        Args:
+            batch (dict): Input batch containing data.
+            x_init (torch.Tensor, optional): Initial state. Defaults to None.
+
+
+        Returns:
+            torch.Tensor: Initialized state.
+        """
+        if h_state is not None:
+            self.h_state = h_state
+        else:
+            self.h_state = torch.zeros_like(batch.input).detach().requires_grad_(True)
+
+
+    def format2D_3D(self, x):
+        if hasattr(self.grad_mod, "dim_3d"):
+            if self.grad_mod.dim_3d:
+                x = x.unsqueeze(1)
+
+
+        return x
+
+
+    def solver_step(self, state, batch, step, alpha_step=1.0):
         """
         Perform a single optimization step.
+
 
         Args:
             state (torch.Tensor): Current state.
             batch (dict): Input batch containing data.
-            step (int): Current optimization step.
+            step (int): Current optimization step between 0 and 1.
+
 
         Returns:
             torch.Tensor: Updated state.
         """
-        var_cost = self.prior_cost(state) + self.lbd**2 * self.obs_cost(state, batch)
-        grad = torch.autograd.grad(var_cost, state, create_graph=True)[0]
 
-        gmod = self.grad_mod(grad)
-        state_update = 1 / (step + 1) * gmod + self.lr_grad * (step + 1) / self.n_step * grad
+
+        if isinstance(step, float):
+            t = torch.tensor([step], device=state.device).repeat(state.shape[0])
+        else:
+            t = step
+
+
+        if "subgrad" in self.input_grad_update:
+            gobs = (batch.input - state).nan_to_num()
+
+
+            gprior = state - self.prior_cost.forward_ae(state)
+            grad = torch.concatenate(
+                (self.format2D_3D(gobs), self.format2D_3D(gprior)), dim=1
+            )
+
+
+            if "state" in self.input_grad_update:
+                grad = torch.concatenate((grad, self.format2D_3D(state)), dim=1)
+
+
+            if "previous" in self.input_grad_update:
+                grad = torch.concatenate((grad, self.format2D_3D(self.h_state)), dim=1)
+
+
+        elif "gradsplit" in self.input_grad_update:
+            prior_cost = self.prior_cost(state)
+            obs_cost = self.obs_cost(state, batch)
+            # Compute full gradient
+            grad_prior = torch.autograd.grad(prior_cost, state, create_graph=True)[0]
+            grad_obs = torch.autograd.grad(obs_cost, state, create_graph=True)[0]
+            grad = torch.concatenate((grad_prior, grad_obs), dim=1)
+            if "state" in self.input_grad_update:
+                grad = grad / ((grad**2).mean().sqrt().detach())
+                grad = torch.concatenate((grad, state), dim=1)
+
+
+        elif "grad" in self.input_grad_update:
+            var_cost = self.prior_cost(state) + self.lbd**2 * self.obs_cost(
+                state, batch
+            )
+            grad = torch.autograd.grad(var_cost, state, create_graph=True)[0]
+
+
+            if "state" in self.input_grad_update:
+                grad = grad / ((grad**2).mean().sqrt().detach())
+                grad = torch.concatenate((grad, self.format2D_3D(state)), dim=1)
+
+
+            if "previous" in self.input_grad_update:
+                grad = torch.concatenate((grad, self.format2D_3D(self.h_state)), dim=1)
+
+
+        elif self.input_grad_update == "obs-only":
+            grad = batch.input.nan_to_num()
+
+
+        elif self.input_grad_update == "obs+state":
+            grad = torch.concatenate(
+                (self.format2D_3D(state), self.format2D_3D(batch.input.nan_to_num())),
+                dim=1,
+            )
+
+
+        gmod = self.grad_mod(grad, timesteps=t, extra=None)
+        if hasattr(self.grad_mod, "dim_3d"):
+            if self.grad_mod.dim_3d:
+                gmod = gmod.squeeze(1)
+
+
+        state_update = alpha_step * gmod
+        if ("grad" in self.input_grad_update) and (self.lr_grad > 0.0):
+            state_update += (
+                self.lr_grad
+                * (step + 1)
+                / self.n_step
+                * grad[:, : state.shape[1], :, :]
+            )
+
+
+        self.h_state = state_update
+
 
         return state - state_update
 
-    def forward(self, batch):
+
+    def forward(self, batch, x_init=None, h_state=None, phase="test"):
         """
         Perform the forward pass of the solver.
 
+
         Args:
             batch (dict): Input batch containing data.
+
 
         Returns:
             torch.Tensor: Final optimized state.
         """
         with torch.set_grad_enabled(True):
-            state = self.init_state(batch)
+            state = self.init_state(batch, x_init=x_init)
+            self.init_h_state(batch, h_state=h_state)
             self.grad_mod.reset_state(batch.input)
 
-            for step in range(self.n_step):
-                state = self.solver_step(state, batch, step=step)
-                if not self.training:
-                    state = state.detach().requires_grad_(True)
 
             if not self.training:
-                state = self.prior_cost.forward_ae(state)
+                if ("subgrad" in self.input_grad_update) or (
+                    "grad" not in self.input_grad_update
+                ):
+                    state.requires_grad_(False)
+                    self.h_state.requires_grad_(False)
+
+
+            for step in range(self.n_step):
+                alpha_step = 1.0 / self.n_step
+                state = self.solver_step(state, batch, step=step/self.n_step, alpha_step=alpha_step)
+                if (not self.training) and ("grad" in self.input_grad_update):
+                    if "subgrad" in self.input_grad_update:
+                        state = state.detach().requires_grad_(False)
+                    else:
+                        state = state.detach().requires_grad_(True)
+
+
         return state
 
 
@@ -517,6 +674,7 @@ class ConvLstmGradModel(nn.Module):
         out = self.conv_out(hidden)
         out = self.up(out)
         return out
+
 
 
 # ===================================================

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -13,7 +13,6 @@ Classes:
 """
 
 from pathlib import Path
-from typing import Optional
 import pandas as pd
 import pytorch_lightning as pl
 import kornia.filters as kfilts
@@ -22,9 +21,9 @@ from torch import nn
 import torch.nn.functional as F
 
 
-#===================================================
+# ===================================================
 # Lightning Modules
-#====================================================
+# ====================================================
 
 class LitModel(pl.LightningModule):
     """
@@ -41,8 +40,7 @@ class LitModel(pl.LightningModule):
     """
 
     def __init__(
-        self, solver, rec_weight, opt_fn, test_metrics=None,
-        pre_metric_fn=None, norm_stats=None, persist_rw=True
+        self, solver, rec_weight, opt_fn, test_metrics=None, pre_metric_fn=None, norm_stats=None, persist_rw=True
     ):
         """
         Initialize the Lit4dVarNet module.
@@ -58,7 +56,7 @@ class LitModel(pl.LightningModule):
         """
         super().__init__()
         self.solver = solver
-        self.register_buffer('rec_weight', torch.from_numpy(rec_weight), persistent=persist_rw)
+        self.register_buffer("rec_weight", torch.from_numpy(rec_weight), persistent=persist_rw)
         self.test_data = None
         self._norm_stats = norm_stats
         self.opt_fn = opt_fn
@@ -77,7 +75,7 @@ class LitModel(pl.LightningModule):
             return self._norm_stats
         elif self.trainer.datamodule is not None:
             return self.trainer.datamodule.norm_stats()
-        return (0., 1.)
+        return (0.0, 1.0)
 
     @staticmethod
     def weighted_mse(err, weight):
@@ -171,7 +169,9 @@ class LitModel(pl.LightningModule):
         grad_loss = self.weighted_mse(kfilts.sobel(out) - kfilts.sobel(batch.tgt), self.rec_weight)
 
         with torch.no_grad():
-            self.log(f"{phase}_mse", 10000 * loss * self.norm_stats[1]**2, prog_bar=True, on_step=False, on_epoch=True)
+            self.log(
+                f"{phase}_mse", 10000 * loss * self.norm_stats[1] ** 2, prog_bar=True, on_step=False, on_epoch=True
+            )
             self.log(f"{phase}_loss", loss, prog_bar=True, on_step=False, on_epoch=True)
             self.log(f"{phase}_gloss", grad_loss, prog_bar=True, on_step=False, on_epoch=True)
 
@@ -199,14 +199,16 @@ class LitModel(pl.LightningModule):
         out = self(batch=batch)
         m, s = self.norm_stats
 
-        self.test_data.append(torch.stack(
-            [
-                batch.input.cpu() * s + m,
-                batch.tgt.cpu() * s + m,
-                out.squeeze(dim=-1).detach().cpu() * s + m,
-            ],
-            dim=1,
-        ))
+        self.test_data.append(
+            torch.stack(
+                [
+                    batch.input.cpu() * s + m,
+                    batch.tgt.cpu() * s + m,
+                    out.squeeze(dim=-1).detach().cpu() * s + m,
+                ],
+                dim=1,
+            )
+        )
 
     @property
     def test_quantities(self):
@@ -216,7 +218,7 @@ class LitModel(pl.LightningModule):
         Returns:
             list: List of test quantity names.
         """
-        return ['inp', 'tgt', 'out']
+        return ["inp", "tgt", "out"]
 
     def on_test_epoch_end(self):
         """
@@ -224,27 +226,20 @@ class LitModel(pl.LightningModule):
 
         This includes logging metrics and saving test data.
         """
-        rec_da = self.trainer.test_dataloaders.dataset.reconstruct(
-            self.test_data, self.rec_weight.cpu().numpy()
-        )
+        rec_da = self.trainer.test_dataloaders.dataset.reconstruct(self.test_data, self.rec_weight.cpu().numpy())
 
         if isinstance(rec_da, list):
             rec_da = rec_da[0]
 
-        self.test_data = rec_da.assign_coords(
-            dict(v0=self.test_quantities)
-        ).to_dataset(dim='v0')
+        self.test_data = rec_da.assign_coords(dict(v0=self.test_quantities)).to_dataset(dim="v0")
 
         metric_data = self.test_data.pipe(self.pre_metric_fn)
-        metrics = pd.Series({
-            metric_n: metric_fn(metric_data)
-            for metric_n, metric_fn in self.metrics.items()
-        })
+        metrics = pd.Series({metric_n: metric_fn(metric_data) for metric_n, metric_fn in self.metrics.items()})
 
         print(metrics.to_frame(name="Metrics").to_markdown())
         if self.logger:
-            self.test_data.to_netcdf(Path(self.logger.log_dir) / 'test_data.nc')
-            print(Path(self.trainer.log_dir) / 'test_data.nc')
+            self.test_data.to_netcdf(Path(self.logger.log_dir) / "test_data.nc")
+            print(Path(self.trainer.log_dir) / "test_data.nc")
             self.logger.log_metrics(metrics.to_dict())
 
 
@@ -274,7 +269,7 @@ class Lit4dVarNet(LitModel):
 
 #===================================================
 # Solvers
-#====================================================
+# ====================================================
 
 class GradSolver(nn.Module):
     """
@@ -344,10 +339,7 @@ class GradSolver(nn.Module):
         grad = torch.autograd.grad(var_cost, state, create_graph=True)[0]
 
         gmod = self.grad_mod(grad)
-        state_update = (
-            1 / (step + 1) * gmod
-            + self.lr_grad * (step + 1) / self.n_step * grad
-        )
+        state_update = 1 / (step + 1) * gmod + self.lr_grad * (step + 1) / self.n_step * grad
 
         return state - state_update
 
@@ -377,7 +369,8 @@ class GradSolver(nn.Module):
 
 #===================================================
 # Modeles (UNET, ConvLSTM)
-#====================================================
+# ====================================================
+
 
 class GradModelWithCondition(torch.nn.Module):
     """
@@ -387,7 +380,7 @@ class GradModelWithCondition(torch.nn.Module):
         grad_model : grad update model
     """
 
-    def __init__(self, grad_model=False, dropout=0.,use_grad_norm=True):
+    def __init__(self, grad_model=False, dropout=0.0, use_grad_norm=True):
         """
         Initialize the ConvLstmGradModel.
 
@@ -399,10 +392,10 @@ class GradModelWithCondition(torch.nn.Module):
         self.dropout = torch.nn.Dropout(dropout)
         self.use_grad_norm = use_grad_norm
 
-        if hasattr(self.grad_model, 'dim_3d') == True:
+        if hasattr(self.grad_model, "dim_3d"):
             self.dim_3d = self.grad_model.dim_3d
 
-        if hasattr(self.grad_model, 'dims') == True:
+        if hasattr(self.grad_model, "dims"):
             if self.grad_model.dims == 3:
                 self.dim_3d = True
 
@@ -411,7 +404,7 @@ class GradModelWithCondition(torch.nn.Module):
         Args:
             inp (torch.Tensor): Input tensor to determine state size.
         """
-        #Initialize hidden and cell state for LSTM if use a ConvLstmGradModel, otherwise set to None
+        # Initialize hidden and cell state for LSTM if use a ConvLstmGradModel, otherwise set to None
         if hasattr(self.grad_model, "dim_hidden"):
             size = [inp.shape[0], self.grad_model.dim_hidden, *inp.shape[-2:]]
             if hasattr(self.grad_model, "downsamp"):
@@ -424,11 +417,9 @@ class GradModelWithCondition(torch.nn.Module):
                 self.down(torch.zeros(size, device=inp.device)),
             ]
         else:
-            self._state = None, None  
+            self._state = None, None
 
         self._grad_norm = None
-
-
 
     def forward(self, x, timesteps=None, extra=[]):
         """
@@ -445,9 +436,9 @@ class GradModelWithCondition(torch.nn.Module):
             if self.use_grad_norm:
                 self._grad_norm = (x**2).mean().sqrt()
             else:
-                self._grad_norm = 1.
+                self._grad_norm = 1.0
 
-        #print('self._grad_norm in GradModelWithCondition:', self._grad_norm, flush=True)
+        # print('self._grad_norm in GradModelWithCondition:', self._grad_norm, flush=True)
         x = x / self._grad_norm
         hidden, cell = self._state
         x = self.dropout(x)
@@ -489,20 +480,12 @@ class ConvLstmGradModel(nn.Module):
             padding=kernel_size // 2,
         )
 
-        self.conv_out = torch.nn.Conv2d(
-            dim_hidden, dim_in, kernel_size=kernel_size, padding=kernel_size // 2
-        )
+        self.conv_out = torch.nn.Conv2d(dim_hidden, dim_in, kernel_size=kernel_size, padding=kernel_size // 2)
 
         self.dropout = torch.nn.Dropout(dropout)
         self._state = []
         self.down = nn.AvgPool2d(downsamp) if downsamp is not None else nn.Identity()
-        self.up = (
-            nn.UpsamplingBilinear2d(scale_factor=downsamp)
-            if downsamp is not None
-            else nn.Identity()
-        )
-
-
+        self.up = nn.UpsamplingBilinear2d(scale_factor=downsamp) if downsamp is not None else nn.Identity()
 
     def predict(self, x, timesteps=None, extra=[], hidden=None, cell=None):
         """
@@ -517,16 +500,14 @@ class ConvLstmGradModel(nn.Module):
         # if self._grad_norm is None:
         #     self._grad_norm = (x**2).mean().sqrt()
         # x = x / self._grad_norm
-        #hidden, cell = self._state
-        #x = self.dropout(x)
+        # hidden, cell = self._state
+        # x = self.dropout(x)
         x = self.down(x)
         gates = self.gates(torch.cat((x, hidden), 1))
 
         in_gate, remember_gate, out_gate, cell_gate = gates.chunk(4, 1)
 
-        in_gate, remember_gate, out_gate = map(
-            torch.sigmoid, [in_gate, remember_gate, out_gate]
-        )
+        in_gate, remember_gate, out_gate = map(torch.sigmoid, [in_gate, remember_gate, out_gate])
         cell_gate = torch.tanh(cell_gate)
 
         cell = (remember_gate * cell) + (in_gate * cell_gate)
@@ -538,11 +519,10 @@ class ConvLstmGradModel(nn.Module):
         return out
 
 
-
-
-#===================================================
+# ===================================================
 # Observation Cost and Prior Cost
-#====================================================
+# ====================================================
+
 
 class BaseObsCost(nn.Module):
     """
@@ -606,33 +586,17 @@ class BilinAEPriorCost(nn.Module):
         """
         super().__init__()
         self.bilin_quad = bilin_quad
-        self.conv_in = nn.Conv2d(
-            dim_in, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2
-        )
-        self.conv_hidden = nn.Conv2d(
-            dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2
-        )
+        self.conv_in = nn.Conv2d(dim_in, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2)
+        self.conv_hidden = nn.Conv2d(dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2)
 
-        self.bilin_1 = nn.Conv2d(
-            dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2
-        )
-        self.bilin_21 = nn.Conv2d(
-            dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2
-        )
-        self.bilin_22 = nn.Conv2d(
-            dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2
-        )
+        self.bilin_1 = nn.Conv2d(dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2)
+        self.bilin_21 = nn.Conv2d(dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2)
+        self.bilin_22 = nn.Conv2d(dim_hidden, dim_hidden, kernel_size=kernel_size, padding=kernel_size // 2)
 
-        self.conv_out = nn.Conv2d(
-            2 * dim_hidden, dim_in, kernel_size=kernel_size, padding=kernel_size // 2
-        )
+        self.conv_out = nn.Conv2d(2 * dim_hidden, dim_in, kernel_size=kernel_size, padding=kernel_size // 2)
 
         self.down = nn.AvgPool2d(downsamp) if downsamp is not None else nn.Identity()
-        self.up = (
-            nn.UpsamplingBilinear2d(scale_factor=downsamp)
-            if downsamp is not None
-            else nn.Identity()
-        )
+        self.up = nn.UpsamplingBilinear2d(scale_factor=downsamp) if downsamp is not None else nn.Identity()
 
     def forward_ae(self, x):
         """
@@ -648,14 +612,8 @@ class BilinAEPriorCost(nn.Module):
         x = self.conv_in(x)
         x = self.conv_hidden(F.relu(x))
 
-        nonlin = (
-            self.bilin_21(x)**2
-            if self.bilin_quad
-            else (self.bilin_21(x) * self.bilin_22(x))
-        )
-        x = self.conv_out(
-            torch.cat([self.bilin_1(x), nonlin], dim=1)
-        )
+        nonlin = self.bilin_21(x) ** 2 if self.bilin_quad else (self.bilin_21(x) * self.bilin_22(x))
+        x = self.conv_out(torch.cat([self.bilin_1(x), nonlin], dim=1))
         x = self.up(x)
         return x
 

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -13,6 +13,7 @@ Classes:
 """
 
 from pathlib import Path
+from typing import Optional
 import pandas as pd
 import pytorch_lightning as pl
 import kornia.filters as kfilts
@@ -20,6 +21,10 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
+
+#===================================================
+# Lightning Modules
+#====================================================
 
 class LitModel(pl.LightningModule):
     """
@@ -267,6 +272,10 @@ class Lit4dVarNet(LitModel):
         return base_loss + 1.0 * prior_cost
 
 
+#===================================================
+# Solvers
+#====================================================
+
 class GradSolver(nn.Module):
     """
     A gradient-based solver for optimization in 4D-VarNet.
@@ -366,6 +375,87 @@ class GradSolver(nn.Module):
         return state
 
 
+#===================================================
+# Modeles (UNET, ConvLSTM)
+#====================================================
+
+class GradModelWithCondition(torch.nn.Module):
+    """
+    A generic conditional model for gradient modulation.
+
+    Attributes:
+        grad_model : grad update model
+    """
+
+    def __init__(self, grad_model=False, dropout=0.,use_grad_norm=True):
+        """
+        Initialize the ConvLstmGradModel.
+
+        Args:
+            grad_model : grad update model
+        """
+        super().__init__()
+        self.grad_model = grad_model
+        self.dropout = torch.nn.Dropout(dropout)
+        self.use_grad_norm = use_grad_norm
+
+        if hasattr(self.grad_model, 'dim_3d') == True:
+            self.dim_3d = self.grad_model.dim_3d
+
+        if hasattr(self.grad_model, 'dims') == True:
+            if self.grad_model.dims == 3:
+                self.dim_3d = True
+
+    def reset_state(self, inp):
+        """
+        Args:
+            inp (torch.Tensor): Input tensor to determine state size.
+        """
+        #Initialize hidden and cell state for LSTM if use a ConvLstmGradModel, otherwise set to None
+        if hasattr(self.grad_model, "dim_hidden"):
+            size = [inp.shape[0], self.grad_model.dim_hidden, *inp.shape[-2:]]
+            if hasattr(self.grad_model, "downsamp"):
+                downsamp = self.grad_model.downsamp
+            else:
+                downsamp = None
+            self.down = nn.AvgPool2d(downsamp) if downsamp is not None else nn.Identity()
+            self._state = [
+                self.down(torch.zeros(size, device=inp.device)),
+                self.down(torch.zeros(size, device=inp.device)),
+            ]
+        else:
+            self._state = None, None  
+
+        self._grad_norm = None
+
+
+
+    def forward(self, x, timesteps=None, extra=[]):
+        """
+        Perform the forward pass of the LSTM.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor.
+        """
+
+        if self._grad_norm is None:
+            if self.use_grad_norm:
+                self._grad_norm = (x**2).mean().sqrt()
+            else:
+                self._grad_norm = 1.
+
+        #print('self._grad_norm in GradModelWithCondition:', self._grad_norm, flush=True)
+        x = x / self._grad_norm
+        hidden, cell = self._state
+        x = self.dropout(x)
+        out = self.grad_model.predict(x, timesteps=timesteps, extra=extra, hidden=hidden, cell=cell)
+
+        return out
+
+
 class ConvLstmGradModel(nn.Module):
     """
     A convolutional LSTM model for gradient modulation.
@@ -412,21 +502,9 @@ class ConvLstmGradModel(nn.Module):
             else nn.Identity()
         )
 
-    def reset_state(self, inp):
-        """
-        Reset the internal state of the LSTM.
 
-        Args:
-            inp (torch.Tensor): Input tensor to determine state size.
-        """
-        size = [inp.shape[0], self.dim_hidden, *inp.shape[-2:]]
-        self._grad_norm = None
-        self._state = [
-            self.down(torch.zeros(size, device=inp.device)),
-            self.down(torch.zeros(size, device=inp.device)),
-        ]
 
-    def forward(self, x):
+    def predict(self, x, timesteps=None, extra=[], hidden=None, cell=None):
         """
         Perform the forward pass of the LSTM.
 
@@ -436,11 +514,11 @@ class ConvLstmGradModel(nn.Module):
         Returns:
             torch.Tensor: Output tensor.
         """
-        if self._grad_norm is None:
-            self._grad_norm = (x**2).mean().sqrt()
-        x = x / self._grad_norm
-        hidden, cell = self._state
-        x = self.dropout(x)
+        # if self._grad_norm is None:
+        #     self._grad_norm = (x**2).mean().sqrt()
+        # x = x / self._grad_norm
+        #hidden, cell = self._state
+        #x = self.dropout(x)
         x = self.down(x)
         gates = self.gates(torch.cat((x, hidden), 1))
 
@@ -459,6 +537,12 @@ class ConvLstmGradModel(nn.Module):
         out = self.up(out)
         return out
 
+
+
+
+#===================================================
+# Observation Cost and Prior Cost
+#====================================================
 
 class BaseObsCost(nn.Module):
     """

--- a/ocean4dvarnet/unet.py
+++ b/ocean4dvarnet/unet.py
@@ -1,0 +1,838 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the CC-by-NC license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Modified from https://github.com/openai/guided-diffusion/blob/main/guided_diffusion/unet.py
+"""
+
+import math
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+
+
+
+@dataclass(eq=False)
+class UNetModel(nn.Module):
+    """
+    The full UNet model with attention and timestep embedding.
+    :param in_channels: channels in the input Tensor.
+    :param model_channels: base channel count for the model.
+    :param out_channels: channels in the output Tensor.
+    :param num_res_blocks: number of residual blocks per downsample.
+    :param attention_resolutions: a collection of downsample rates at which
+        attention will take place. May be a set, list, or tuple.
+        For example, if this contains 4, then at 4x downsampling, attention
+        will be used.
+    :param dropout: the dropout probability.
+    :param channel_mult: channel multiplier for each level of the UNet.
+    :param conv_resample: if True, use learned convolutions for upsampling and
+        downsampling.
+    :param dims: determines if the signal is 1D, 2D, or 3D.
+    :param num_classes: if specified (as an int), then this model will be
+        class-conditional with `num_classes` classes.
+    :param use_checkpoint: use gradient checkpointing to reduce memory usage.
+    :param num_heads: the number of attention heads in each attention layer.
+    :param num_heads_channels: if specified, ignore num_heads and instead use
+                               a fixed channel width per attention head.
+    :param num_heads_upsample: works with num_heads to set a different number
+                               of heads for upsampling. Deprecated.
+    :param use_scale_shift_norm: use a FiLM-like conditioning mechanism.
+    :param resblock_updown: use residual blocks for up/downsampling.
+    :param use_new_attention_order: use a different attention pattern for potentially
+                                    increased efficiency.
+    """
+
+    in_channels: int
+    model_channels: int = 128
+    out_channels: int = 3
+    num_res_blocks: int = 2
+    attention_resolutions: Tuple[int] = (1, 2, 2, 2)
+    dropout: float = 0.0
+    channel_mult: Tuple[int] = (1, 2, 4, 8)
+    conv_resample: bool = True
+    dims: int = 2
+    num_classes: Optional[int] = None
+    use_checkpoint: bool = False
+    num_heads: int = 1
+    num_head_channels: int = -1
+    num_heads_upsample: int = -1
+    use_scale_shift_norm: bool = False
+    resblock_updown: bool = False
+    use_new_attention_order: bool = False
+    with_fourier_features: bool = False
+    ignore_time: bool = False
+    input_projection: bool = True
+    bias: bool = True
+    interp_mode: str = 'nearest' #  or 'bilinear'
+
+    image_size: int = -1  # not used...
+    _target_: str = "lib.models.gd_unet.UNetModel"
+
+    def __post_init__(self):
+        super().__init__()
+
+        if self.with_fourier_features:
+            self.in_channels += 12
+
+        if self.num_heads_upsample == -1:
+            self.num_heads_upsample = self.num_heads
+
+        self.time_embed_dim = self.model_channels * 4
+        if self.ignore_time:
+            self.time_embed = lambda x: torch.zeros(
+                x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype
+            )
+        else:
+            self.time_embed = nn.Sequential(
+                linear(self.model_channels, self.time_embed_dim),
+                nn.SiLU(),
+                linear(self.time_embed_dim, self.time_embed_dim),
+            )
+
+        if self.num_classes is not None:
+
+            print('... num_classes :',self.num_classes,flush=True)
+
+            self.label_emb = nn.Embedding(
+                self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes
+            )
+
+        ch = input_ch = int(self.channel_mult[0] * self.model_channels)
+        if self.input_projection:
+            self.input_blocks = nn.ModuleList(
+                [
+                    TimestepEmbedSequential(
+                        conv_nd(self.dims, self.in_channels, ch, 3, padding=1)
+                    )
+                ]
+            )
+        else:
+            self.input_blocks = nn.ModuleList(
+                [TimestepEmbedSequential(torch.nn.Identity())]
+            )
+        self._feature_size = ch
+        input_block_chans = [ch]
+        ds = 1
+        for level, mult in enumerate(self.channel_mult):
+            for _ in range(self.num_res_blocks):
+                layers = [
+                    ResBlock(
+                        ch,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(mult * self.model_channels),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                        bias=self.bias,
+                        interp_mode=self.interp_mode
+                    )
+                ]
+                ch = int(mult * self.model_channels)
+
+                print(ds)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                self.input_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+                input_block_chans.append(ch)
+            if level != len(self.channel_mult) - 1:
+                out_ch = ch
+                self.input_blocks.append(
+                    TimestepEmbedSequential(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            down=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                        )
+                        if self.resblock_updown
+                        else Downsample(
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias
+                        )
+                    )
+                )
+                ch = out_ch
+                input_block_chans.append(ch)
+                ds *= 2
+                self._feature_size += ch
+
+        self.middle_block = TimestepEmbedSequential(
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+            AttentionBlock(
+                ch,
+                use_checkpoint=self.use_checkpoint,
+                num_heads=self.num_heads,
+                num_head_channels=self.num_head_channels,
+                use_new_attention_order=self.use_new_attention_order,
+            ),
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+        )
+        self._feature_size += ch
+
+        self.output_blocks = nn.ModuleList([])
+        for level, mult in list(enumerate(self.channel_mult))[::-1]:
+            for i in range(self.num_res_blocks + 1):
+                ich = input_block_chans.pop()
+                layers = [
+                    ResBlock(
+                        ch + ich,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(self.model_channels * mult),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                        bias=self.bias,
+                        interp_mode=self.interp_mode
+                    )
+                ]
+                ch = int(self.model_channels * mult)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads_upsample,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                if level and i == self.num_res_blocks:
+                    out_ch = ch
+                    layers.append(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            up=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                            bias=self.bias,
+                            interp_mode=self.interp_mode
+                        )
+                        if self.resblock_updown
+                        else Upsample(
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias, interp_mode=self.interp_mode
+                        )
+                    )
+                    ds //= 2
+                self.output_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+
+        self.out = nn.Sequential(
+            normalization(ch),
+            nn.SiLU(),
+            zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
+        )
+    def reset_state(self,x=None):
+        self._grad_norm = None
+
+    def predict(self, x, timesteps, extra, hidden=None, cell=None):
+        """
+        Apply the model to an input batch.
+        :param x: an [N x C x ...] Tensor of inputs.
+        :param timesteps: a 1-D batch of timesteps.
+        :param y: an [N] Tensor of labels, if class-conditional.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+
+        if extra is None:
+            extra = []
+
+        if self.with_fourier_features:
+            z_f = base2_fourier_features(x, start=6, stop=8, step=1)
+            x = torch.cat([x, z_f], dim=1)
+
+        hs = []
+
+        emb = self.time_embed(timestep_embedding(timesteps, self.model_channels).to(x))
+
+        if self.ignore_time:
+            emb = emb * 0.0
+
+        if self.num_classes and "label" not in extra:
+            # Hack to deal with ddp find_unused_parameters not working with activation checkpointing...
+            # self.num_classes corresponds to the pad index of the embedding table
+            extra["label"] = torch.full(
+                (x.size(0),), self.num_classes, dtype=torch.long, device=x.device
+            )
+
+        if self.num_classes is not None and "label" in extra:
+            y = extra["label"]
+            assert (
+                y.shape == x.shape[:1]
+            ), f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
+            emb = emb + self.label_emb(y)
+
+        h = x
+        if "concat_conditioning" in extra:
+            h = torch.cat([x, extra["concat_conditioning"]], dim=1)
+
+        for module in self.input_blocks:
+            h = module(h, emb)
+            hs.append(h)
+        h = self.middle_block(h, emb)
+        for module in self.output_blocks:
+            h = torch.cat([h, hs.pop()], dim=1)
+            h = module(h, emb)
+        h = h.type(x.dtype)
+        result = self.out(h)
+        return result
+
+    def forward(self, batch, timesteps=None, extra=None):
+        x = batch.input
+        x = x.nan_to_num()
+
+        if timesteps is None:
+            timesteps = torch.zeros((x.shape[0],), device=x.device, dtype=torch.long)
+        if extra is None:
+            extra = []
+
+        out = self.predict(x, timesteps, extra)
+
+
+        #if self.dims+2 > len(batch.input.shape):
+        #    out = out.view(out.shape[0], out.shape[2], out.shape[3], out.shape[4] ) # add channel dim if missing
+
+        return out
+    
+
+
+def linear(*args, **kwargs):
+    """
+    Create a linear module.
+    """
+    return nn.Linear(*args, **kwargs)
+
+class TimestepBlock(nn.Module):
+    """
+    Any module where forward() takes timestep embeddings as a second argument.
+    """
+
+    @abstractmethod
+    def forward(self, x, emb):
+        """
+        Apply the module to `x` given `emb` timestep embeddings.
+        """
+
+
+class TimestepEmbedSequential(nn.Sequential, TimestepBlock):
+    """
+    A sequential module that passes timestep embeddings to the children that
+    support it as an extra input.
+    """
+
+    def forward(self, x, emb):
+        for layer in self:
+            if isinstance(layer, TimestepBlock):
+                x = layer(x, emb)
+            else:
+                x = layer(x)
+        return x
+    
+
+
+
+
+def conv_nd(dims, *args, **kwargs):
+    """
+    Create a 1D, 2D, or 3D convolution module.
+    """
+    if dims == 1:
+        return nn.Conv1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.Conv2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.Conv3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+
+class ResBlock(TimestepBlock):
+    """
+    A residual block that can optionally change the number of channels.
+    :param channels: the number of input channels.
+    :param emb_channels: the number of timestep embedding channels.
+    :param dropout: the rate of dropout.
+    :param out_channels: if specified, the number of out channels.
+    :param use_conv: if True and out_channels is specified, use a spatial
+        convolution instead of a smaller 1x1 convolution to change the
+        channels in the skip connection.
+    :param dims: determines if the signal is 1D, 2D, or 3D.
+    :param use_checkpoint: if True, use gradient checkpointing on this module.
+    :param up: if True, use this block for upsampling.
+    :param down: if True, use this block for downsampling.
+    """
+
+    def __init__(
+        self,
+        channels,
+        emb_channels,
+        dropout,
+        out_channels=None,
+        use_conv=False,
+        use_scale_shift_norm=False,
+        dims=2,
+        use_checkpoint=False,
+        up=False,
+        down=False,
+        emb_off=False,
+        bias=True,
+        interp_mode='nearest',
+    ):
+        super().__init__()
+        self.channels = channels
+        self.emb_channels = emb_channels
+        self.dropout = dropout
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.use_checkpoint = use_checkpoint
+        self.use_scale_shift_norm = use_scale_shift_norm
+
+        self.in_layers = nn.Sequential(
+            normalization(channels),
+            nn.SiLU(),
+            conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias),
+        )
+
+        self.updown = up or down
+
+        if up:
+            self.h_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
+            self.x_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
+        elif down:
+            self.h_upd = Downsample(channels, False, dims, bias=bias)
+            self.x_upd = Downsample(channels, False, dims, bias=bias)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        if emb_off:
+            self.emb_layers = ConstantEmbedding(
+                emb_channels,
+                2 * self.out_channels if use_scale_shift_norm else self.out_channels,
+            )
+        else:
+            self.emb_layers = nn.Sequential(
+                nn.SiLU(),
+                linear(
+                    emb_channels,
+                    2 * self.out_channels
+                    if use_scale_shift_norm
+                    else self.out_channels,
+                ),
+            )
+
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channels),
+            nn.SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(
+                conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1, bias=bias)
+            ),
+        )
+
+        if self.out_channels == channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = conv_nd(
+                dims, channels, self.out_channels, 3, padding=1, bias=bias
+            )
+        else:
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 1, bias=bias)
+
+    def forward(self, x, emb):
+        """
+        Apply the block to a Tensor, conditioned on a timestep embedding.
+        :param x: an [N x C x ...] Tensor of features.
+        :param emb: an [N x emb_channels] Tensor of timestep embeddings.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+        return checkpoint(
+            self._forward,
+            (x, emb),
+            self.parameters(),
+            self.use_checkpoint and self.training,
+        )
+
+    def _forward(self, x, emb):
+        if self.updown:
+            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+            h = in_rest(x)
+            h = self.h_upd(h)
+            x = self.x_upd(x)
+            h = in_conv(h)
+        else:
+            h = self.in_layers(x)
+        emb_out = self.emb_layers(emb).type(h.dtype)
+        while len(emb_out.shape) < len(h.shape):
+            emb_out = emb_out[..., None]
+        if self.use_scale_shift_norm:
+            out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+            scale, shift = torch.chunk(emb_out, 2, dim=1)
+            h = out_norm(h) * (1 + scale) + shift
+            h = out_rest(h)
+        else:
+            h = h + emb_out
+            h = self.out_layers(h)
+        return self.skip_connection(x) + h
+
+
+def normalization(channels):
+    """
+    Make a standard normalization layer.
+    :param channels: number of input channels.
+    :return: an nn.Module for normalization.
+    """
+    return GroupNorm32(32, channels)
+
+class GroupNorm32(nn.GroupNorm):
+    def forward(self, x):
+        return super().forward(x.float()).type(x.dtype)
+
+
+
+class Upsample(nn.Module):
+    """
+    An upsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
+                 upsampling occurs in the inner-two dimensions.
+    """
+
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True, interp_mode='nearest'):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        if interp_mode != 'nearest' :
+             self.interp_mode = interp_mode
+        if use_conv:
+            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1, bias=bias)
+    
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+
+        if hasattr(self, 'interp_mode') is False:
+            self.interp_mode = 'nearest'
+
+        if self.dims == 3:
+            x = F.interpolate(
+                x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode=self.interp_mode
+            )
+        else:
+            x = F.interpolate(x, scale_factor=2, mode=self.interp_mode)
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+
+class Downsample(nn.Module):
+    """
+    A downsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
+                 downsampling occurs in the inner-two dimensions.
+    """
+
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        stride = 2 if dims != 3 else (1, 2, 2)
+        if use_conv:
+            self.op = conv_nd(
+                dims, self.channels, self.out_channels, 3, stride=stride, padding=1, bias=bias
+            )
+        else:
+            assert self.channels == self.out_channels
+            self.op = avg_pool_nd(dims, kernel_size=stride, stride=stride)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        return self.op(x)
+    
+
+class ConstantEmbedding(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.embedding_table = nn.Parameter(torch.empty((1, out_channels)))
+        nn.init.uniform_(
+            self.embedding_table, -(in_channels**0.5), in_channels**0.5
+        )
+
+    def forward(self, emb):
+        return self.embedding_table.repeat(emb.shape[0], 1)
+
+
+
+def zero_module(module):
+    """
+    Zero out the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+def checkpoint(func, inputs, params, flag):
+    """
+    Evaluate a function without caching intermediate activations, allowing for
+    reduced memory at the expense of extra compute in the backward pass.
+    :param func: the function to evaluate.
+    :param inputs: the argument sequence to pass to `func`.
+    :param params: a sequence of parameters `func` depends on but does not
+                   explicitly take as arguments.
+    :param flag: if False, disable gradient checkpointing.
+    """
+    if flag:
+        # Use pytorch's activation checkpointing.  This has support for fp16 autocast
+        return torch.utils.checkpoint.checkpoint(func, *inputs)
+        # args = tuple(inputs) + tuple(params)
+        # return CheckpointFunction.apply(func, len(inputs), *args)
+    else:
+        return func(*inputs)
+    
+
+
+def avg_pool_nd(dims, *args, **kwargs):
+    """
+    Create a 1D, 2D, or 3D average pooling module.
+    """
+    if dims == 1:
+        return nn.AvgPool1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.AvgPool2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.AvgPool3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+class AttentionBlock(nn.Module):
+    """
+    An attention block that allows spatial positions to attend to each other.
+    Originally ported from here, but adapted to the N-d case.
+    https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/models/unet.py#L66.
+    """
+
+    def __init__(
+        self,
+        channels,
+        num_heads=1,
+        num_head_channels=-1,
+        use_checkpoint=False,
+        use_new_attention_order=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        if num_head_channels == -1:
+            self.num_heads = num_heads
+        else:
+            assert (
+                channels % num_head_channels == 0
+            ), f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            self.num_heads = channels // num_head_channels
+        self.use_checkpoint = use_checkpoint
+        self.norm = normalization(channels)
+        self.qkv = conv_nd(1, channels, channels * 3, 1)
+        if use_new_attention_order:
+            # split qkv before split heads
+            self.attention = QKVAttention(self.num_heads)
+        else:
+            # split heads before split qkv
+            self.attention = QKVAttentionLegacy(self.num_heads)
+
+        self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
+
+    def forward(self, x):
+        return checkpoint(
+            self._forward,
+            (x,),
+            self.parameters(),
+            self.use_checkpoint and self.training,
+        )
+
+    def _forward(self, x):
+        b, c, *spatial = x.shape
+        x = x.reshape(b, c, -1)
+        qkv = self.qkv(self.norm(x))
+        h = self.attention(qkv)
+        h = self.proj_out(h)
+        return (x + h).reshape(b, c, *spatial)
+
+
+
+
+class QKVAttentionLegacy(nn.Module):
+    """
+    A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (H * 3 * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts", q * scale, k * scale
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v)
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
+
+
+class QKVAttention(nn.Module):
+    """
+    A module which performs QKV attention and splits in a different order.
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (3 * H * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.chunk(3, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts",
+            (q * scale).view(bs * self.n_heads, ch, length),
+            (k * scale).view(bs * self.n_heads, ch, length),
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum(
+            "bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length)
+        )
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
+
+
+def count_flops_attn(model, _x, y):
+    """
+    A counter for the `thop` package to count the operations in an
+    attention operation.
+    Meant to be used like:
+        macs, params = thop.profile(
+            model,
+            inputs=(inputs, timestamps),
+            custom_ops={QKVAttention: QKVAttention.count_flops},
+        )
+    """
+    b, c, *spatial = y[0].shape
+    num_spatial = int(np.prod(spatial))
+    # We perform two matmuls with the same number of ops.
+    # The first computes the weight matrix, the second computes
+    # the combination of the value vectors.
+    matmul_ops = 2 * b * (num_spatial**2) * c
+    model.total_ops += torch.DoubleTensor([matmul_ops])
+
+
+
+def base2_fourier_features(
+    inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1
+) -> torch.Tensor:
+    freqs = torch.arange(start, stop, step, device=inputs.device, dtype=inputs.dtype)
+
+    # Create Base 2 Fourier features
+    w = 2.0**freqs * 2 * np.pi
+    w = torch.tile(w[None, :], (1, inputs.size(1)))
+
+    # Compute features
+    h = torch.repeat_interleave(inputs, len(freqs), dim=1)
+    h = w[:, :, None, None] * h
+    h = torch.cat([torch.sin(h), torch.cos(h)], dim=1)
+    return h
+
+
+
+def timestep_embedding(timesteps, dim, max_period=10000):
+    """
+    Create sinusoidal timestep embeddings.
+    :param timesteps: a 1-D Tensor of N indices, one per batch element.
+                      These may be fractional.
+    :param dim: the dimension of the output.
+    :param max_period: controls the minimum frequency of the embeddings.
+    :return: an [N x dim] Tensor of positional embeddings.
+    """
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+    ).to(device=timesteps.device)
+    args = timesteps[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding

--- a/ocean4dvarnet/unet.py
+++ b/ocean4dvarnet/unet.py
@@ -16,8 +16,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import math
-
 
 
 @dataclass(eq=False)
@@ -72,7 +70,7 @@ class UNetModel(nn.Module):
     ignore_time: bool = False
     input_projection: bool = True
     bias: bool = True
-    interp_mode: str = 'nearest' #  or 'bilinear'
+    interp_mode: str = "nearest"  #  or 'bilinear'
 
     image_size: int = -1  # not used...
     _target_: str = "lib.models.gd_unet.UNetModel"
@@ -88,9 +86,7 @@ class UNetModel(nn.Module):
 
         self.time_embed_dim = self.model_channels * 4
         if self.ignore_time:
-            self.time_embed = lambda x: torch.zeros(
-                x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype
-            )
+            self.time_embed = lambda x: torch.zeros(x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype)
         else:
             self.time_embed = nn.Sequential(
                 linear(self.model_channels, self.time_embed_dim),
@@ -99,26 +95,17 @@ class UNetModel(nn.Module):
             )
 
         if self.num_classes is not None:
+            print("... num_classes :", self.num_classes, flush=True)
 
-            print('... num_classes :',self.num_classes,flush=True)
-
-            self.label_emb = nn.Embedding(
-                self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes
-            )
+            self.label_emb = nn.Embedding(self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes)
 
         ch = input_ch = int(self.channel_mult[0] * self.model_channels)
         if self.input_projection:
             self.input_blocks = nn.ModuleList(
-                [
-                    TimestepEmbedSequential(
-                        conv_nd(self.dims, self.in_channels, ch, 3, padding=1)
-                    )
-                ]
+                [TimestepEmbedSequential(conv_nd(self.dims, self.in_channels, ch, 3, padding=1))]
             )
         else:
-            self.input_blocks = nn.ModuleList(
-                [TimestepEmbedSequential(torch.nn.Identity())]
-            )
+            self.input_blocks = nn.ModuleList([TimestepEmbedSequential(torch.nn.Identity())])
         self._feature_size = ch
         input_block_chans = [ch]
         ds = 1
@@ -135,7 +122,7 @@ class UNetModel(nn.Module):
                         use_scale_shift_norm=self.use_scale_shift_norm,
                         emb_off=self.ignore_time and self.num_classes is None,
                         bias=self.bias,
-                        interp_mode=self.interp_mode
+                        interp_mode=self.interp_mode,
                     )
                 ]
                 ch = int(mult * self.model_channels)
@@ -170,9 +157,7 @@ class UNetModel(nn.Module):
                             emb_off=self.ignore_time and self.num_classes is None,
                         )
                         if self.resblock_updown
-                        else Downsample(
-                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias
-                        )
+                        else Downsample(ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias)
                     )
                 )
                 ch = out_ch
@@ -224,7 +209,7 @@ class UNetModel(nn.Module):
                         use_scale_shift_norm=self.use_scale_shift_norm,
                         emb_off=self.ignore_time and self.num_classes is None,
                         bias=self.bias,
-                        interp_mode=self.interp_mode
+                        interp_mode=self.interp_mode,
                     )
                 ]
                 ch = int(self.model_channels * mult)
@@ -252,11 +237,16 @@ class UNetModel(nn.Module):
                             up=True,
                             emb_off=self.ignore_time and self.num_classes is None,
                             bias=self.bias,
-                            interp_mode=self.interp_mode
+                            interp_mode=self.interp_mode,
                         )
                         if self.resblock_updown
                         else Upsample(
-                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias, interp_mode=self.interp_mode
+                            ch,
+                            self.conv_resample,
+                            dims=self.dims,
+                            out_channels=out_ch,
+                            bias=self.bias,
+                            interp_mode=self.interp_mode,
                         )
                     )
                     ds //= 2
@@ -268,7 +258,8 @@ class UNetModel(nn.Module):
             nn.SiLU(),
             zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
         )
-    def reset_state(self,x=None):
+
+    def reset_state(self, x=None):
         self._grad_norm = None
 
     def predict(self, x, timesteps, extra, hidden=None, cell=None):
@@ -297,15 +288,13 @@ class UNetModel(nn.Module):
         if self.num_classes and "label" not in extra:
             # Hack to deal with ddp find_unused_parameters not working with activation checkpointing...
             # self.num_classes corresponds to the pad index of the embedding table
-            extra["label"] = torch.full(
-                (x.size(0),), self.num_classes, dtype=torch.long, device=x.device
-            )
+            extra["label"] = torch.full((x.size(0),), self.num_classes, dtype=torch.long, device=x.device)
 
         if self.num_classes is not None and "label" in extra:
             y = extra["label"]
-            assert (
-                y.shape == x.shape[:1]
-            ), f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
+            assert y.shape == x.shape[:1], (
+                f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
+            )
             emb = emb + self.label_emb(y)
 
         h = x
@@ -334,12 +323,10 @@ class UNetModel(nn.Module):
 
         out = self.predict(x, timesteps, extra)
 
-
-        #if self.dims+2 > len(batch.input.shape):
+        # if self.dims+2 > len(batch.input.shape):
         #    out = out.view(out.shape[0], out.shape[2], out.shape[3], out.shape[4] ) # add channel dim if missing
 
         return out
-    
 
 
 def linear(*args, **kwargs):
@@ -347,6 +334,7 @@ def linear(*args, **kwargs):
     Create a linear module.
     """
     return nn.Linear(*args, **kwargs)
+
 
 class TimestepBlock(nn.Module):
     """
@@ -373,9 +361,6 @@ class TimestepEmbedSequential(nn.Sequential, TimestepBlock):
             else:
                 x = layer(x)
         return x
-    
-
-
 
 
 def conv_nd(dims, *args, **kwargs):
@@ -389,7 +374,6 @@ def conv_nd(dims, *args, **kwargs):
     elif dims == 3:
         return nn.Conv3d(*args, **kwargs)
     raise ValueError(f"unsupported dimensions: {dims}")
-
 
 
 class ResBlock(TimestepBlock):
@@ -422,7 +406,7 @@ class ResBlock(TimestepBlock):
         down=False,
         emb_off=False,
         bias=True,
-        interp_mode='nearest',
+        interp_mode="nearest",
     ):
         super().__init__()
         self.channels = channels
@@ -460,9 +444,7 @@ class ResBlock(TimestepBlock):
                 nn.SiLU(),
                 linear(
                     emb_channels,
-                    2 * self.out_channels
-                    if use_scale_shift_norm
-                    else self.out_channels,
+                    2 * self.out_channels if use_scale_shift_norm else self.out_channels,
                 ),
             )
 
@@ -470,17 +452,13 @@ class ResBlock(TimestepBlock):
             normalization(self.out_channels),
             nn.SiLU(),
             nn.Dropout(p=dropout),
-            zero_module(
-                conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1, bias=bias)
-            ),
+            zero_module(conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1, bias=bias)),
         )
 
         if self.out_channels == channels:
             self.skip_connection = nn.Identity()
         elif use_conv:
-            self.skip_connection = conv_nd(
-                dims, channels, self.out_channels, 3, padding=1, bias=bias
-            )
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias)
         else:
             self.skip_connection = conv_nd(dims, channels, self.out_channels, 1, bias=bias)
 
@@ -529,10 +507,10 @@ def normalization(channels):
     """
     return GroupNorm32(32, channels)
 
+
 class GroupNorm32(nn.GroupNorm):
     def forward(self, x):
         return super().forward(x.float()).type(x.dtype)
-
 
 
 class Upsample(nn.Module):
@@ -544,28 +522,25 @@ class Upsample(nn.Module):
                  upsampling occurs in the inner-two dimensions.
     """
 
-    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True, interp_mode='nearest'):
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True, interp_mode="nearest"):
         super().__init__()
         self.channels = channels
         self.out_channels = out_channels or channels
         self.use_conv = use_conv
         self.dims = dims
-        if interp_mode != 'nearest' :
-             self.interp_mode = interp_mode
+        if interp_mode != "nearest":
+            self.interp_mode = interp_mode
         if use_conv:
             self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1, bias=bias)
-    
 
     def forward(self, x):
         assert x.shape[1] == self.channels
 
-        if hasattr(self, 'interp_mode') is False:
-            self.interp_mode = 'nearest'
+        if hasattr(self, "interp_mode") is False:
+            self.interp_mode = "nearest"
 
         if self.dims == 3:
-            x = F.interpolate(
-                x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode=self.interp_mode
-            )
+            x = F.interpolate(x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode=self.interp_mode)
         else:
             x = F.interpolate(x, scale_factor=2, mode=self.interp_mode)
         if self.use_conv:
@@ -590,9 +565,7 @@ class Downsample(nn.Module):
         self.dims = dims
         stride = 2 if dims != 3 else (1, 2, 2)
         if use_conv:
-            self.op = conv_nd(
-                dims, self.channels, self.out_channels, 3, stride=stride, padding=1, bias=bias
-            )
+            self.op = conv_nd(dims, self.channels, self.out_channels, 3, stride=stride, padding=1, bias=bias)
         else:
             assert self.channels == self.out_channels
             self.op = avg_pool_nd(dims, kernel_size=stride, stride=stride)
@@ -600,19 +573,16 @@ class Downsample(nn.Module):
     def forward(self, x):
         assert x.shape[1] == self.channels
         return self.op(x)
-    
+
 
 class ConstantEmbedding(nn.Module):
     def __init__(self, in_channels, out_channels):
         super().__init__()
         self.embedding_table = nn.Parameter(torch.empty((1, out_channels)))
-        nn.init.uniform_(
-            self.embedding_table, -(in_channels**0.5), in_channels**0.5
-        )
+        nn.init.uniform_(self.embedding_table, -(in_channels**0.5), in_channels**0.5)
 
     def forward(self, emb):
         return self.embedding_table.repeat(emb.shape[0], 1)
-
 
 
 def zero_module(module):
@@ -641,7 +611,6 @@ def checkpoint(func, inputs, params, flag):
         # return CheckpointFunction.apply(func, len(inputs), *args)
     else:
         return func(*inputs)
-    
 
 
 def avg_pool_nd(dims, *args, **kwargs):
@@ -677,9 +646,9 @@ class AttentionBlock(nn.Module):
         if num_head_channels == -1:
             self.num_heads = num_heads
         else:
-            assert (
-                channels % num_head_channels == 0
-            ), f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            assert channels % num_head_channels == 0, (
+                f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            )
             self.num_heads = channels // num_head_channels
         self.use_checkpoint = use_checkpoint
         self.norm = normalization(channels)
@@ -710,8 +679,6 @@ class AttentionBlock(nn.Module):
         return (x + h).reshape(b, c, *spatial)
 
 
-
-
 class QKVAttentionLegacy(nn.Module):
     """
     A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
@@ -732,9 +699,7 @@ class QKVAttentionLegacy(nn.Module):
         ch = width // (3 * self.n_heads)
         q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
         scale = 1 / math.sqrt(math.sqrt(ch))
-        weight = torch.einsum(
-            "bct,bcs->bts", q * scale, k * scale
-        )  # More stable with f16 than dividing afterwards
+        weight = torch.einsum("bct,bcs->bts", q * scale, k * scale)  # More stable with f16 than dividing afterwards
         weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
         a = torch.einsum("bts,bcs->bct", weight, v)
         return a.reshape(bs, -1, length)
@@ -770,9 +735,7 @@ class QKVAttention(nn.Module):
             (k * scale).view(bs * self.n_heads, ch, length),
         )  # More stable with f16 than dividing afterwards
         weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        a = torch.einsum(
-            "bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length)
-        )
+        a = torch.einsum("bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length))
         return a.reshape(bs, -1, length)
 
     @staticmethod
@@ -800,10 +763,7 @@ def count_flops_attn(model, _x, y):
     model.total_ops += torch.DoubleTensor([matmul_ops])
 
 
-
-def base2_fourier_features(
-    inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1
-) -> torch.Tensor:
+def base2_fourier_features(inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1) -> torch.Tensor:
     freqs = torch.arange(start, stop, step, device=inputs.device, dtype=inputs.dtype)
 
     # Create Base 2 Fourier features
@@ -817,7 +777,6 @@ def base2_fourier_features(
     return h
 
 
-
 def timestep_embedding(timesteps, dim, max_period=10000):
     """
     Create sinusoidal timestep embeddings.
@@ -828,9 +787,9 @@ def timestep_embedding(timesteps, dim, max_period=10000):
     :return: an [N x dim] Tensor of positional embeddings.
     """
     half = dim // 2
-    freqs = torch.exp(
-        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
-    ).to(device=timesteps.device)
+    freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half).to(
+        device=timesteps.device
+    )
     args = timesteps[:, None].float() * freqs[None]
     embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
     if dim % 2:

--- a/ocean4dvarnet/unet.py
+++ b/ocean4dvarnet/unet.py
@@ -95,8 +95,7 @@ class UNetModel(nn.Module):
             )
 
         if self.num_classes is not None:
-            print("... num_classes :", self.num_classes, flush=True)
-
+            # print("... num_classes :", self.num_classes, flush=True)
             self.label_emb = nn.Embedding(self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes)
 
         ch = input_ch = int(self.channel_mult[0] * self.model_channels)
@@ -127,7 +126,6 @@ class UNetModel(nn.Module):
                 ]
                 ch = int(mult * self.model_channels)
 
-                print(ds)
                 if ds in self.attention_resolutions:
                     layers.append(
                         AttentionBlock(


### PR DESCRIPTION
## Source project
This development has been developed in a fork for ocean4dvarnet package and tested within the 4dvarnet-starter project.

## Problem solved / Contribution
In this branch, we created a new generic class for gradmodels : 'GradModelWithCondition'. This class allows to call for each gradmodel.predict(x,...). It is usefull for Unet because (1) we can directly call Unet outside a GradSolver by calling Unet(batch), and we can use it inside the generic class GradModelWithCondition by calling Unet.predict(x). 
We also created a python file for Unet OpenAI (unet.py) which can be used, when GradSolver will be updated with step embedding. Finally we updated the ConvLSTM class so it can be called by GradModelWithCondition.

## Technical description
When calling a grad_mod, we now call for GradModelWithCondition. One argument is grad_model which can be ConvLSTM or Unet. 

## Pre-submission checklist
- [x ] The code works in the source project
- [x ] No variables or paths specific to the source project
- [ ] Dependencies are declared in pyproject.toml
- [ ] `ruff check .` reports no errors : only a problem with load_dc_data function which was already in ocean4dvarnet.
- [x ] I reviewed the full diff before opening the PR
- [ ] I discussed this contribution with the maintainer beforehand

## How to test
I used the base config in 4dvarnet-starter project and called for functions from the ocean4dvarnet package. I progressively modified the classes called with the new classes writed.
