### PR TITLE
Adding Lazy Loading and Edge handling

### DIFF
--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -664,18 +664,18 @@ class LazyDataModule(BaseDataModule):
         """
         self.train_ds = LazyXrDataset(
             {k: v.sel(self.domains['train']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=self.post_fn('train'),
+            **self.xrds_kw["train"], postpro_fn=self.post_fn('train'),
         )
         if self.aug_kw:
             self.train_ds = AugmentedDataset(self.train_ds, **self.aug_kw)
 
         self.val_ds = LazyXrDataset(
             {k: v.sel(self.domains['val']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=self.post_fn('val'),
+            **self.xrds_kw["val"], postpro_fn=self.post_fn('val'),
         )
         self.test_ds = LazyXrDataset(
             {k: v.sel(self.domains['test']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=self.post_fn('test'),
+            **self.xrds_kw["test"], postpro_fn=self.post_fn('test'),
         )
 
     def norm_stats(self, phase=None):

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -263,10 +263,20 @@ class LazyXrDataset(XrDataset):
 
         Args:
             das (dict): xr.DataArray to be used.
-            patch_dims (dict):  da dimension and sizes of patches to extract.
-            domain_limits (dict, optional): da dimension slices of domain, to Limits for selecting a subset of the domain. for patch extractions
-            strides (dict, optional): dims to strides size for patch extraction. (default to one)
-            postpro_fn (callable, optional): A function for post-processing extracted patches.
+            patch_dims (dict): da dimension and sizes of patches to extract.
+            domain_limits (dict, optional): da dimension slices of domain, to
+                Limits for selecting a subset of the domain. for patch
+                extractions
+            strides (dict, optional): dims to strides size for patch extraction.
+                (default to one)
+            postpro_fn (callable, optional): A function for post-processing
+                extracted patches.
+            edges (dict): if the theoretical coverage of a patch exceeds
+                the domain's limits, this parameter can fill the "blank"
+                area of the patch by repeating the other side of the
+                domain ("periodic") or fill the gap with `nan` values
+                ("fill_nan")).
+                Example: `edges=dict(lat="fill_nan", lon="periodic")`.
         """
         self.return_coords = False
         self.postpro_fn = postpro_fn
@@ -280,6 +290,20 @@ class LazyXrDataset(XrDataset):
             dim: max((da_dims[dim] - patch_dims[dim]) // self.strides.get(dim, 1) + 1, 0)
             for dim in patch_dims
         }
+
+        # If an edge-behaviour is specified for a dimension, increment
+        # by one self.ds_size along this dimension
+        self.edges = kwargs.get('edges', dict())
+        for dim, behaviour in self.edges.items():
+            if behaviour not in ('periodic', 'fill_nan'):
+                raise ValueError(
+                    f"edges[{dim}] must be either 'periodic' or 'fill_nan', "
+                    + f"got {behaviour}"
+                )
+
+            if (da_dims[dim] - patch_dims[dim]) % strides[dim] != 0:
+                self.ds_size[dim] += 1
+
 
     def __getitem__(self, item):
         """
@@ -304,15 +328,46 @@ class LazyXrDataset(XrDataset):
             )
 
         ref = next(iter(self.da))
+        sliced_domain = self.da[ref].isel(**sl)
 
         if self.return_coords:
-            item = self.da[ref].isel(**sl)
+            item = sliced_domain
             return item.coords.to_dataset()[list(self.patch_dims)]
+
+        das = {k: self.da[k].isel(**sl) for k in self.da}
+
+        # Handling edge behaviour
+        for dim, behaviour in self.edges.items():
+            if len(sliced_domain) >= self.patch_dims[dim]:
+                continue
+            offset = self.patch_dims[dim] - len(sliced_domain[dim])
+
+            if behaviour == 'periodic':
+                sl[dim] = slice(
+                    sl[dim].start - offset, sl[dim].stop - offset,
+                )
+
+                for var in das:
+                    das[var] = (
+                        self.da[var]
+                        .isel(time=sl['time'])  # TODO How to make it generic?
+                        .roll({dim: -offset})
+                        .assign_coords({dim: lambda x: x[dim] - offset})
+                        .sortby(dim)
+                        .isel({k: v for k, v in sl.items() if k != 'time'})
+                    )
+            elif behaviour == 'fill_nan':
+                for var in das:
+                    das[var] = das[var].pad(
+                        pad_width=dict({dim: (0, offset)}),
+                        mode='constant',
+                        constant_values=np.nan,
+                    )
 
         item = (
             xr.Dataset(
-                data_vars={k: v.isel(**sl) for (k, v) in self.da.items()},
-                coords=self.da[ref].isel(**sl).coords,
+                data_vars=das,
+                coords=next(iter(das.values())).coords,
             )
             .to_dataarray()
             .sortby('variable')
@@ -588,6 +643,12 @@ class LazyDataModule(BaseDataModule):
         """
         super().__init__(*args, **kwargs)
 
+        if not isinstance(self.input_da, dict):
+            raise TypeError(
+                "Argument `input_da` is expected to be a `dict`, "
+                + f"got `{type(self.input_da)}`."
+            )
+
         if self._norm_stats is None:
             raise TypeError(
                 "Normalisation parameters (argument `norm_stats`) must "
@@ -645,7 +706,6 @@ class LazyDataModule(BaseDataModule):
             lambda item: item._replace(tgt=normalize(item.tgt)),
             lambda item: item._replace(input=normalize(item.input)),
         ])
-
 
 
 class ConcatDataModule(BaseDataModule):

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -233,13 +233,13 @@ class XrDataset(torch.utils.data.Dataset):
         das = [xr.DataArray(it.numpy(), dims=dims, coords=co.coords)
                for it, co in zip(items, coords)]
 
-        da_shape = dict(zip(coords[0].dims, self.da.shape[-len(coords[0].dims):]))
+        da_shape = dict(zip(coords[0].dims, self._get_da_sample().shape[-len(coords[0].dims):]))
         new_shape = dict(zip(new_dims, items[0].shape[:len(new_dims)]))
 
         rec_da = xr.DataArray(
             np.zeros([*new_shape.values(), *da_shape.values()]),
             dims=dims,
-            coords={d: self.da[d] for d in self.patch_dims}
+            coords={d: self._get_da_sample()[d] for d in self.patch_dims}
         )
         count_da = xr.zeros_like(rec_da)
 
@@ -248,6 +248,9 @@ class XrDataset(torch.utils.data.Dataset):
             count_da.loc[da.coords] = count_da.sel(da.coords) + w
 
         return rec_da / count_da
+
+    def _get_da_sample(self):
+        return self.da
 
 
 class LazyXrDataset(XrDataset):
@@ -344,6 +347,9 @@ class LazyXrDataset(XrDataset):
                     "All provided xr.DataArray must share the same coordinates "
                     + f"({ref} != {k})"
                 )
+
+    def _get_da_sample(self):
+        return self.da[next(iter(self.da))]
 
 
 class XrConcatDataset(torch.utils.data.ConcatDataset):
@@ -595,22 +601,51 @@ class LazyDataModule(BaseDataModule):
         Args:
             stage (str, optional): Stage of the setup ('train', 'val', 'test').
         """
-        post_fn = self.post_fn()
         self.train_ds = LazyXrDataset(
             {k: v.sel(self.domains['train']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=post_fn,
+            **self.xrds_kw, postpro_fn=self.post_fn('train'),
         )
         if self.aug_kw:
             self.train_ds = AugmentedDataset(self.train_ds, **self.aug_kw)
 
         self.val_ds = LazyXrDataset(
             {k: v.sel(self.domains['val']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=post_fn,
+            **self.xrds_kw, postpro_fn=self.post_fn('val'),
         )
         self.test_ds = LazyXrDataset(
             {k: v.sel(self.domains['test']) for (k, v) in self.input_da.items()},
-            **self.xrds_kw, postpro_fn=post_fn,
+            **self.xrds_kw, postpro_fn=self.post_fn('test'),
         )
+
+    def norm_stats(self, phase=None):
+        """
+        Compute or retrieve normalization statistics (mean, std).
+
+        Returns:
+            tuple: Normalization statistics (mean, std).
+        """
+        if self._norm_stats is None:
+            self._norm_stats = self.train_mean_std()
+            print("Norm stats", self._norm_stats)
+        return self._norm_stats[phase]
+
+
+    def post_fn(self, phase=None):
+        """
+        Create a post-processing function for normalizing data depending
+        on the dataset (training, validation or test dataset).
+
+        Returns:
+            callable: Post-processing function.
+        """
+        m, s = self.norm_stats(phase)
+        def normalize(item): return (item - m) / s
+        return ft.partial(ft.reduce, lambda i, f: f(i), [
+            TrainingItem._make,
+            lambda item: item._replace(tgt=normalize(item.tgt)),
+            lambda item: item._replace(input=normalize(item.input)),
+        ])
+
 
 
 class ConcatDataModule(BaseDataModule):

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -1,9 +1,9 @@
 """
 This module provides data handling utilities for 4D-VarNet models.
 
-It includes classes and functions for creating datasets, augmenting data, 
-managing data loading pipelines, and reconstructing data from patches. 
-These utilities are designed to work seamlessly with PyTorch and xarray, 
+It includes classes and functions for creating datasets, augmenting data,
+managing data loading pipelines, and reconstructing data from patches.
+These utilities are designed to work seamlessly with PyTorch and xarray,
 enabling efficient data preprocessing and loading for machine learning tasks.
 
 Classes:
@@ -200,7 +200,7 @@ class XrDataset(torch.utils.data.Dataset):
 
         Args:
             batches (list): List of patches (torch tensor) corresponding to batches without shuffle.
-            weight (np.ndarray, optional): Tensor of size patch_dims corresponding to the weight of a prediction 
+            weight (np.ndarray, optional): Tensor of size patch_dims corresponding to the weight of a prediction
                 depending on the position on the patch (default to ones everywhere). Overlapping patches will
                 be averaged with weighting.
 
@@ -248,6 +248,102 @@ class XrDataset(torch.utils.data.Dataset):
             count_da.loc[da.coords] = count_da.sel(da.coords) + w
 
         return rec_da / count_da
+
+
+class LazyXrDataset(XrDataset):
+    def __init__(
+        self, das, patch_dims, domain_limits=None, strides=None,
+        postpro_fn=None, **kwargs,
+    ):
+        """
+        Initialize the LazyXrDataset.
+
+        Args:
+            das (dict): xr.DataArray to be used.
+            patch_dims (dict):  da dimension and sizes of patches to extract.
+            domain_limits (dict, optional): da dimension slices of domain, to Limits for selecting a subset of the domain. for patch extractions
+            strides (dict, optional): dims to strides size for patch extraction. (default to one)
+            postpro_fn (callable, optional): A function for post-processing extracted patches.
+        """
+        self.return_coords = False
+        self.postpro_fn = postpro_fn
+        self.da = {k: v.sel(**(domain_limits)) for (k, v) in das.items()}
+        self._check_dims_and_coords()
+        self.patch_dims = patch_dims
+        self.strides = strides or {}
+        ref = next(iter(self.da))
+        da_dims = dict(zip(self.da[ref].dims, self.da[ref].shape))
+        self.ds_size = {
+            dim: max((da_dims[dim] - patch_dims[dim]) // self.strides.get(dim, 1) + 1, 0)
+            for dim in patch_dims
+        }
+
+    def __getitem__(self, item):
+        """
+        Get a specific patch by index.
+
+        Args:
+            item (int): Index of the patch.
+
+        Returns:
+            Patch data or coordinates, depending on the mode.
+        """
+        sl = {}
+        _zip = zip(
+            self.ds_size.keys(),
+            np.unravel_index(item, tuple(self.ds_size.values())),
+        )
+
+        for dim, idx in _zip:
+            sl[dim] = slice(
+                self.strides.get(dim, 1) * idx,
+                self.strides.get(dim, 1) * idx + self.patch_dims[dim]
+            )
+
+        ref = next(iter(self.da))
+
+        if self.return_coords:
+            item = self.da[ref].isel(**sl)
+            return item.coords.to_dataset()[list(self.patch_dims)]
+
+        item = (
+            xr.Dataset(
+                data_vars={k: v.isel(**sl) for (k, v) in self.da.items()},
+                coords=self.da[ref].isel(**sl).coords,
+            )
+            .to_dataarray()
+            .sortby('variable')
+            .data
+            .astype(np.float32)
+        )
+
+        if self.postpro_fn is not None:
+            return self.postpro_fn(item)
+        return item
+
+    def _check_dims_and_coords(self):
+        """
+        Check that `self.da`'s xr.DataArrays all share the same dims and
+        coords.
+        """
+        ref = next(iter(self.da))
+        ref_val = self.da[ref]
+
+        for k, v in self.da.items():
+            if ref == k:
+                continue
+
+            if ref_val.dims != v.dims:
+                raise ValueError(
+                    "All provided xr.DataArray must share the same dimensions "
+                    + f"({ref} != {k})"
+                )
+
+            if not ref_val.coords.equals(v.coords):
+                raise ValueError(
+                    "All provided xr.DataArray must share the same coordinates "
+                    + f"({ref} != {k})"
+                )
 
 
 class XrConcatDataset(torch.utils.data.ConcatDataset):
@@ -471,6 +567,50 @@ class BaseDataModule(pl.LightningDataModule):
             DataLoader: Testing DataLoader.
         """
         return torch.utils.data.DataLoader(self.test_ds, shuffle=False, **self.dl_kw)
+
+
+class LazyDataModule(BaseDataModule):
+
+    def __init__(self, *args, **kwargs):
+        """
+        See BaseDataModule.__init__.
+
+        Differences are:
+        - `input_da` must contain a xr.Dataset-valued dictionary;
+        - `norm_stats` must be indicated, otherwise a TypeError will be
+            raised.
+        """
+        super().__init__(*args, **kwargs)
+
+        if self._norm_stats is None:
+            raise TypeError(
+                "Normalisation parameters (argument `norm_stats`) must "
+                + "be provided in lazy loading"
+            )
+
+    def setup(self, stage='test'):
+        """
+        Set up the datasets for training, validation, and testing.
+
+        Args:
+            stage (str, optional): Stage of the setup ('train', 'val', 'test').
+        """
+        post_fn = self.post_fn()
+        self.train_ds = LazyXrDataset(
+            {k: v.sel(self.domains['train']) for (k, v) in self.input_da.items()},
+            **self.xrds_kw, postpro_fn=post_fn,
+        )
+        if self.aug_kw:
+            self.train_ds = AugmentedDataset(self.train_ds, **self.aug_kw)
+
+        self.val_ds = LazyXrDataset(
+            {k: v.sel(self.domains['val']) for (k, v) in self.input_da.items()},
+            **self.xrds_kw, postpro_fn=post_fn,
+        )
+        self.test_ds = LazyXrDataset(
+            {k: v.sel(self.domains['test']) for (k, v) in self.input_da.items()},
+            **self.xrds_kw, postpro_fn=post_fn,
+        )
 
 
 class ConcatDataModule(BaseDataModule):

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -280,6 +280,8 @@ class LazyXrDataset(XrDataset):
         """
         self.return_coords = False
         self.postpro_fn = postpro_fn
+        print("DOMAIN LIMITS:", domain_limits)
+        print("DATA VARS:", das.keys())
         self.da = {k: v.sel(**(domain_limits)) for (k, v) in das.items()}
         self._check_dims_and_coords()
         self.patch_dims = patch_dims

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -723,6 +723,71 @@ class LazyDataModule(BaseDataModule):
         ])
 
 
+class NoisyLazyDataModule(LazyDataModule):
+    """
+    A data module that adds noise to input data if specified.
+
+    The noise added to the training data is a standardised gaussian noise
+    scaled by a provided noise level.
+    The noise added to the validation data is uniformly drawn from the
+    interval [-n, n] where n is the noise level.
+
+    Attributes: see LazyDataModule.
+        noise (float): Noise level to apply.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize the NoisyLazyDataModule.
+
+        Args:
+            input_da (xarray.DataArray): The input data array.
+            domains (dict): Dictionary of domain splits (train, val, test).
+            xrds_kw (dict): Keyword arguments for XrDataset.
+            dl_kw (dict): Keyword arguments for DataLoader.
+            aug_kw (dict, optional): Keyword arguments for AugmentedDataset.
+            norm_stats (tuple, optional): Normalization statistics (mean, std).
+            noise (float, optional): Noise level to be added to the input.
+        """
+        super().__init__(*args, **kwargs)
+        self._rng = np.random.default_rng()
+        self.noise = kwargs.get('noise')  # in meters
+
+        if self.noise:
+            logging.info(
+                f"Adding noise level of {self.noise} m to input data"
+            )
+        else:
+            logging.warning(
+                "You are using NoisyLazyDataModule and yet, you did not "
+                + "provide a noise level!"
+            )
+
+    def post_fn(self, phase=None):
+        m, s = self.norm_stats(phase)
+
+        def add_noise(x):
+            nl = self.noise
+
+            if not nl:
+                return x  # identity if no noise
+
+            if phase == 'train':
+                scale = self._rng.uniform(0., nl)
+                noise = scale * self._rng.normal(0., 1., x.shape)
+            elif phase == 'val':
+                noise = self._rng.uniform(-nl, nl, x.shape)
+            else:
+                noise = 0.
+
+            return x + noise.astype(np.float32)
+
+        return ft.partial(ft.reduce, lambda i, f: f(i), [
+            TrainingItem._make,
+            lambda item: item._replace(tgt=(item.tgt - m) / s),
+            lambda item: item._replace(input=(add_noise(item.input) - m) / s),
+        ])
+
+
 class ConcatDataModule(BaseDataModule):
     """A data module for concatenating datasets from multiple domains."""
 

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -257,6 +257,16 @@ class XrDataset(torch.utils.data.Dataset):
 
 
 class LazyXrDataset(XrDataset):
+    """
+    A PyTorch Dataset loading data in lazy mode ("on the fly").
+    If the sampled patch is smaller than the indicated patch dimensions
+    (e. g. a patch sampled at the edge of the domain), the user can
+    complete with nan or periodic repetition in order to return a patch
+    of the specified dimension.
+
+    Attributes: see XrDataset.
+    """
+
     def __init__(
         self, das, patch_dims, domain_limits=None, strides=None,
         postpro_fn=None, **kwargs,
@@ -265,7 +275,7 @@ class LazyXrDataset(XrDataset):
         Initialize the LazyXrDataset.
 
         Args:
-            das (dict): xr.DataArray to be used.
+            das (dict): dictionary containing xr.DataArray to be used.
             patch_dims (dict): da dimension and sizes of patches to extract.
             domain_limits (dict, optional): da dimension slices of domain, to
                 Limits for selecting a subset of the domain. for patch
@@ -306,7 +316,6 @@ class LazyXrDataset(XrDataset):
 
             if (da_dims[dim] - patch_dims[dim]) % strides[dim] != 0:
                 self.ds_size[dim] += 1
-
 
     def __getitem__(self, item):
         """
@@ -634,7 +643,11 @@ class BaseDataModule(pl.LightningDataModule):
 
 
 class LazyDataModule(BaseDataModule):
+    """
+    A data module loading datasets in lazy mode ("on the fly").
 
+    Attributes: see BaseDataModule.
+    """
     def __init__(self, *args, **kwargs):
         """
         See BaseDataModule.__init__.
@@ -692,7 +705,6 @@ class LazyDataModule(BaseDataModule):
             self._norm_stats = self.train_mean_std()
             logger.info(f"Normalisation parameters: {self._norm_stats}")
         return self._norm_stats[phase]
-
 
     def post_fn(self, phase=None):
         """

--- a/ocean4dvarnet/data.py
+++ b/ocean4dvarnet/data.py
@@ -27,11 +27,14 @@ Key Features:
 
 import itertools
 import functools as ft
+import logging
 from collections import namedtuple
 import pytorch_lightning as pl
 import numpy as np
 import torch.utils.data
 import xarray as xr
+
+logger = logging.getLogger(__name__)
 
 TrainingItem = namedtuple('TrainingItem', ['input', 'tgt'])
 
@@ -280,8 +283,6 @@ class LazyXrDataset(XrDataset):
         """
         self.return_coords = False
         self.postpro_fn = postpro_fn
-        print("DOMAIN LIMITS:", domain_limits)
-        print("DATA VARS:", das.keys())
         self.da = {k: v.sel(**(domain_limits)) for (k, v) in das.items()}
         self._check_dims_and_coords()
         self.patch_dims = patch_dims
@@ -551,7 +552,7 @@ class BaseDataModule(pl.LightningDataModule):
         """
         if self._norm_stats is None:
             self._norm_stats = self.train_mean_std()
-            print("Norm stats", self._norm_stats)
+            logger.info(f"Normalisation parameters: {self._norm_stats}")
         return self._norm_stats
 
     def train_mean_std(self, variable='tgt'):
@@ -689,7 +690,7 @@ class LazyDataModule(BaseDataModule):
         """
         if self._norm_stats is None:
             self._norm_stats = self.train_mean_std()
-            print("Norm stats", self._norm_stats)
+            logger.info(f"Normalisation parameters: {self._norm_stats}")
         return self._norm_stats[phase]
 
 

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -33,10 +33,11 @@ class LitModel(pl.LightningModule):
         pre_metric_fn (callable): Preprocessing function for metrics.
         norm_stats (tuple): Normalization statistics (mean, std).
         persist_rw (bool): Whether to persist reconstruction weight as a buffer.
+        nanlim (float): Threshold of "nan" below which, a batch is discarded.
     """
 
     def __init__(
-        self, solver, rec_weight, opt_fn, test_metrics=None, pre_metric_fn=None, norm_stats=None, persist_rw=True
+        self, solver, rec_weight, opt_fn, test_metrics=None, pre_metric_fn=None, norm_stats=None, persist_rw=True, nanlim=.5
     ):
         """
         Initialize the Lit4dVarNet module.
@@ -58,6 +59,7 @@ class LitModel(pl.LightningModule):
         self.opt_fn = opt_fn
         self.metrics = test_metrics or {}
         self.pre_metric_fn = pre_metric_fn or (lambda x: x)
+        self.nanlim = nanlim
 
     @property
     def norm_stats(self):
@@ -142,7 +144,7 @@ class LitModel(pl.LightningModule):
         Returns:
             tuple: Loss and output tensor.
         """
-        if self.training and batch.tgt.isfinite().float().mean() < 0.9:
+        if self.training and batch.tgt.isfinite().float().mean() < self.nanlim:
             return None, None
 
         out = self(batch=batch)

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -7,6 +7,7 @@ using deep learning and PyTorch Lightning.
 """
 
 from pathlib import Path
+import omegaconf
 import pandas as pd
 import pytorch_lightning as pl
 import kornia.filters as kfilts
@@ -163,8 +164,13 @@ class LitModel(pl.LightningModule):
         loss = self.weighted_mse(out - batch.tgt, self.rec_weight)
         grad_loss = self.weighted_mse(kfilts.sobel(out) - kfilts.sobel(batch.tgt), self.rec_weight)
 
+        if isinstance(self.norm_stats, omegaconf.dictconfig.DictConfig):
+            std = self.norm_stats[phase][1]
+        else:
+            std = self.norm_stats[1]
+
         with torch.no_grad():
-            self.log(f"{phase}_mse", 10000 * loss * self.norm_stats[1]**2, prog_bar=True, on_step=False, on_epoch=True)
+            self.log(f"{phase}_mse", 10000 * loss * std**2, prog_bar=True, on_step=False, on_epoch=True)
             self.log(f"{phase}_loss", loss, prog_bar=False, on_step=False, on_epoch=True)
             self.log(f"{phase}_gloss", grad_loss, prog_bar=False, on_step=False, on_epoch=True)
 
@@ -190,7 +196,11 @@ class LitModel(pl.LightningModule):
         if batch_idx == 0:
             self.test_data = []
         out = self(batch=batch)
-        m, s = self.norm_stats
+
+        if isinstance(self.norm_stats, omegaconf.dictconfig.DictConfig):
+            m, s = self.norm_stats['test']
+        else:
+            m, s = self.norm_stats
 
         self.test_data.append(
             torch.stack(

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -164,11 +164,9 @@ class LitModel(pl.LightningModule):
         grad_loss = self.weighted_mse(kfilts.sobel(out) - kfilts.sobel(batch.tgt), self.rec_weight)
 
         with torch.no_grad():
-            self.log(
-                f"{phase}_mse", 10000 * loss * self.norm_stats[1] ** 2, prog_bar=True, on_step=False, on_epoch=True
-            )
-            self.log(f"{phase}_loss", loss, prog_bar=True, on_step=False, on_epoch=True)
-            self.log(f"{phase}_gloss", grad_loss, prog_bar=True, on_step=False, on_epoch=True)
+            self.log(f"{phase}_mse", 10000 * loss * self.norm_stats[1]**2, prog_bar=True, on_step=False, on_epoch=True)
+            self.log(f"{phase}_loss", loss, prog_bar=False, on_step=False, on_epoch=True)
+            self.log(f"{phase}_gloss", grad_loss, prog_bar=False, on_step=False, on_epoch=True)
 
         return 50 * loss + 1000 * grad_loss
 

--- a/ocean4dvarnet/models.py
+++ b/ocean4dvarnet/models.py
@@ -15,6 +15,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 from typing import Optional
+import torch
 
 
 # ===================================================
@@ -278,6 +279,105 @@ class Lit4dVarNet(LitModel):
 
 class GradSolver(nn.Module):
     """
+    A gradient-based solver for optimization in 4D-VarNet.
+
+    Attributes:
+        prior_cost (nn.Module): The prior cost function.
+        obs_cost (nn.Module): The observation cost function.
+        grad_mod (nn.Module): The gradient modulation model.
+        n_step (int): Number of optimization steps.
+        lr_grad (float): Learning rate for gradient updates.
+        lbd (float): Regularization parameter.
+    """
+
+    def __init__(self, prior_cost, obs_cost, grad_mod, n_step, lr_grad=0.2, lbd=1.0, **kwargs):
+        """
+        Initialize the GradSolver.
+
+        Args:
+            prior_cost (nn.Module): The prior cost function.
+            obs_cost (nn.Module): The observation cost function.
+            grad_mod (nn.Module): The gradient modulation model.
+            n_step (int): Number of optimization steps.
+            lr_grad (float, optional): Learning rate for gradient updates. Defaults to 0.2.
+            lbd (float, optional): Regularization parameter. Defaults to 1.0.
+        """
+        super().__init__()
+        self.prior_cost = prior_cost
+        self.obs_cost = obs_cost
+        self.grad_mod = grad_mod
+
+        self.n_step = n_step
+        self.lr_grad = lr_grad
+        self.lbd = lbd
+
+        self._grad_norm = None
+
+    def init_state(self, batch, x_init=None):
+        """
+        Initialize the state for optimization.
+
+        Args:
+            batch (dict): Input batch containing data.
+            x_init (torch.Tensor, optional): Initial state. Defaults to None.
+
+        Returns:
+            torch.Tensor: Initialized state.
+        """
+        if x_init is not None:
+            return x_init
+
+        return batch.input.nan_to_num().detach().requires_grad_(True)
+
+    def solver_step(self, state, batch, step):
+        """
+        Perform a single optimization step.
+
+        Args:
+            state (torch.Tensor): Current state.
+            batch (dict): Input batch containing data.
+            step (int): Current optimization step.
+
+        Returns:
+            torch.Tensor: Updated state.
+        """
+        var_cost = self.prior_cost(state) + self.lbd**2 * self.obs_cost(state, batch)
+        grad = torch.autograd.grad(var_cost, state, create_graph=True)[0]
+
+        gmod = self.grad_mod(grad)
+        state_update = (
+            1 / (step + 1) * gmod
+            + self.lr_grad * (step + 1) / self.n_step * grad
+        )
+
+        return state - state_update
+
+    def forward(self, batch):
+        """
+        Perform the forward pass of the solver.
+
+        Args:
+            batch (dict): Input batch containing data.
+
+        Returns:
+            torch.Tensor: Final optimized state.
+        """
+        with torch.set_grad_enabled(True):
+            state = self.init_state(batch)
+            self.grad_mod.reset_state(batch.input)
+
+            for step in range(self.n_step):
+                state = self.solver_step(state, batch, step=step)
+                if not self.training:
+                    state = state.detach().requires_grad_(True)
+
+            if not self.training:
+                state = self.prior_cost.forward_ae(state)
+        return state
+
+
+class DiffusionGradSolver(GradSolver):
+    """
     Gradient-based solver for optimization within unrolled architectures.
 
     Attributes:
@@ -315,7 +415,7 @@ class GradSolver(nn.Module):
         **kwargs,
     ):
         """
-        Initialize the GradSolver.
+        Initialize the DiffusionGradSolver.
 
         Args:
             prior_cost (nn.Module): The prior cost function.
@@ -327,19 +427,18 @@ class GradSolver(nn.Module):
             input_grad_update (str, optional): Quantities added for updating the input gradient. Defaults to "state".
             std_init (float, optional): Standard deviation for initializing the state. Defaults to 0.1.
         """
-        super().__init__()
-        self.prior_cost = prior_cost
-        self.obs_cost = obs_cost
-        self.grad_mod = grad_mod
-
-        self.n_step = n_step
-        self.lr_grad = lr_grad
-        self.lbd = lbd
+        super().__init__(
+            prior_cost=prior_cost,
+            obs_cost=obs_cost,
+            grad_mod=grad_mod,
+            n_step=n_step,
+            lr_grad=lr_grad,
+            lbd=lbd,
+            **kwargs,
+        )
 
         self.input_grad_update = input_grad_update
         self.std_init = std_init
-
-        self._grad_norm = None
 
     def init_state(self, batch, x_init=None):
         """
@@ -658,6 +757,63 @@ class GradModelWithCondition(torch.nn.Module):
 # ===================================================
 # Observation Cost and Prior Cost
 # ====================================================
+
+class GenericAEPriorCost(torch.nn.Module):
+    """
+    A prior cost model using bilinear autoencoders.
+
+    Attributes:
+        bilin_quad (bool): Whether to use bilinear quadratic terms.
+        conv_in (nn.Conv2d): Convolutional layer for input.
+        conv_hidden (nn.Conv2d): Convolutional layer for hidden states.
+        bilin_1 (nn.Conv2d): Bilinear layer 1.
+        bilin_21 (nn.Conv2d): Bilinear layer 2 (part 1).
+        bilin_22 (nn.Conv2d): Bilinear layer 2 (part 2).
+        conv_out (nn.Conv2d): Convolutional layer for output.
+        down (nn.Module): Downsampling layer.
+        up (nn.Module): Upsampling layer.
+    """
+
+    def __init__(self, model_ae):
+        """
+        Initialize the BilinAEPriorCost module.
+
+        Args:
+            dim_in (int): Number of input dimensions.
+            dim_hidden (int): Number of hidden dimensions.
+            kernel_size (int, optional): Kernel size for convolutions. Defaults to 3.
+            downsamp (int, optional): Downsampling factor. Defaults to None.
+            bilin_quad (bool, optional): Whether to use bilinear quadratic terms. Defaults to True.
+        """
+        super().__init__()
+
+        self.model_ae = model_ae 
+
+    def forward_ae(self, x):
+        """
+        Perform the forward pass through the autoencoder.
+
+        Args:
+            x (torch.Tensor): Input tensor.
+
+        Returns:
+            torch.Tensor: Output tensor after passing through the autoencoder.
+        """
+        timesteps = torch.zeros((x.shape[0],), device=x.device, dtype=torch.long)
+        return self.model_ae.predict(x,timesteps=timesteps, extra=[])
+
+    def forward(self, state):
+        """
+        Compute the prior cost using the autoencoder.
+
+        Args:
+            state (torch.Tensor): The current state tensor.
+
+        Returns:
+            torch.Tensor: The computed prior cost.
+        """
+        return torch.nn.functional.mse_loss(state, self.forward_ae(state))
+
 
 class BaseObsCost(nn.Module):
     """

--- a/ocean4dvarnet/train.py
+++ b/ocean4dvarnet/train.py
@@ -7,7 +7,9 @@ Functions:
 """
 
 import torch
+import logging
 torch.set_float32_matmul_precision('high')
+logger = logging.getLogger(__name__)
 
 
 def base_training(trainer, dm, lit_mod, ckpt=None):
@@ -24,9 +26,7 @@ def base_training(trainer, dm, lit_mod, ckpt=None):
         None
     """
     if trainer.logger is not None:
-        print()
-        print("Logdir:", trainer.logger.log_dir)
-        print()
+        logger.info(f"Log directory: {trainer.logger.log_dir}")
 
     trainer.fit(lit_mod, datamodule=dm, ckpt_path=ckpt)
     trainer.test(lit_mod, datamodule=dm, ckpt_path='best')
@@ -53,9 +53,7 @@ def multi_dm_training(
         None
     """
     if trainer.logger is not None:
-        print()
-        print("Logdir:", trainer.logger.log_dir)
-        print()
+        logger.info(f"Log directory: {trainer.logger.log_dir}")
 
     trainer.fit(lit_mod, datamodule=dm, ckpt_path=ckpt)
 

--- a/ocean4dvarnet/unet.py
+++ b/ocean4dvarnet/unet.py
@@ -16,6 +16,716 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import math
+
+# PyTorch 1.7 has SiLU, but we support PyTorch 1.5.
+class SiLU(nn.Module):
+    def forward(self, x):
+        return x * torch.sigmoid(x)
+
+
+class GroupNorm32(nn.GroupNorm):
+    def forward(self, x):
+        return super().forward(x.float()).type(x.dtype)
+
+
+def conv_nd(dims, *args, **kwargs):
+    """
+    Create a 1D, 2D, or 3D convolution module.
+    """
+    if dims == 1:
+        return nn.Conv1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.Conv2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.Conv3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def linear(*args, **kwargs):
+    """
+    Create a linear module.
+    """
+    return nn.Linear(*args, **kwargs)
+
+
+def avg_pool_nd(dims, *args, **kwargs):
+    """
+    Create a 1D, 2D, or 3D average pooling module.
+    """
+    if dims == 1:
+        return nn.AvgPool1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.AvgPool2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.AvgPool3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def update_ema(target_params, source_params, rate=0.99):
+    """
+    Update target parameters to be closer to those of source parameters using
+    an exponential moving average.
+    :param target_params: the target parameter sequence.
+    :param source_params: the source parameter sequence.
+    :param rate: the EMA rate (closer to 1 means slower).
+    """
+    for targ, src in zip(target_params, source_params):
+        targ.detach().mul_(rate).add_(src, alpha=1 - rate)
+
+
+def zero_module(module):
+    """
+    Zero out the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+def scale_module(module, scale):
+    """
+    Scale the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().mul_(scale)
+    return module
+
+
+def mean_flat(tensor):
+    """
+    Take the mean over all non-batch dimensions.
+    """
+    return tensor.mean(dim=list(range(1, len(tensor.shape))))
+
+
+def normalization(channels):
+    """
+    Make a standard normalization layer.
+    :param channels: number of input channels.
+    :return: an nn.Module for normalization.
+    """
+    # On ne peut pas avoir plus de groupes que de channels
+    num_groups = min(32, channels)
+
+    # On cherche le plus grand nombre de groupes qui divise channels
+    while channels % num_groups != 0:
+        num_groups -= 1
+
+    return GroupNorm32(num_groups, channels)
+
+
+def timestep_embedding(timesteps, dim, max_period=10000):
+    """
+    Create sinusoidal timestep embeddings.
+    :param timesteps: a 1-D Tensor of N indices, one per batch element.
+                      These may be fractional.
+    :param dim: the dimension of the output.
+    :param max_period: controls the minimum frequency of the embeddings.
+    :return: an [N x dim] Tensor of positional embeddings.
+    """
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+    ).to(device=timesteps.device)
+    args = timesteps[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding
+
+
+def checkpoint(func, inputs, params, flag):
+    """
+    Evaluate a function without caching intermediate activations, allowing for
+    reduced memory at the expense of extra compute in the backward pass.
+    :param func: the function to evaluate.
+    :param inputs: the argument sequence to pass to `func`.
+    :param params: a sequence of parameters `func` depends on but does not
+                   explicitly take as arguments.
+    :param flag: if False, disable gradient checkpointing.
+    """
+    if flag:
+        # Use pytorch's activation checkpointing.  This has support for fp16 autocast
+        return torch.utils.checkpoint.checkpoint(func, *inputs,use_reentrant=False)
+        # args = tuple(inputs) + tuple(params)
+        # return CheckpointFunction.apply(func, len(inputs), *args)
+    else:
+        return func(*inputs)
+
+
+class CheckpointFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, run_function, length, *args):
+        ctx.run_function = run_function
+        ctx.input_tensors = list(args[:length])
+        ctx.input_params = list(args[length:])
+        with torch.no_grad():
+            output_tensors = ctx.run_function(*ctx.input_tensors)
+        return output_tensors
+
+    @staticmethod
+    def backward(ctx, *output_grads):
+        ctx.input_tensors = [x.detach().requires_grad_(True) for x in ctx.input_tensors]
+        with torch.enable_grad():
+            # Fixes a bug where the first op in run_function modifies the
+            # Tensor storage in place, which is not allowed for detach()'d
+            # Tensors.
+            shallow_copies = [x.view_as(x) for x in ctx.input_tensors]
+            output_tensors = ctx.run_function(*shallow_copies)
+        input_grads = torch.autograd.grad(
+            output_tensors,
+            ctx.input_tensors + ctx.input_params,
+            output_grads,
+            allow_unused=True,
+        )
+        del ctx.input_tensors
+        del ctx.input_params
+        del output_tensors
+        return (None, None) + input_grads
+
+class ConstantEmbedding(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.embedding_table = nn.Parameter(torch.empty((1, out_channels)))
+        nn.init.uniform_(
+            self.embedding_table, -(in_channels**0.5), in_channels**0.5
+        )
+
+    def forward(self, emb):
+        return self.embedding_table.repeat(emb.shape[0], 1)
+
+
+class AttentionPool2d(nn.Module):
+    """
+    Adapted from CLIP: https://github.com/openai/CLIP/blob/main/clip/model.py
+    """
+
+    def __init__(
+        self,
+        spacial_dim: int,
+        embed_dim: int,
+        num_heads_channels: int,
+        output_dim: int = None,
+    ):
+        super().__init__()
+        self.positional_embedding = nn.Parameter(
+            torch.randn(embed_dim, spacial_dim**2 + 1) / embed_dim**0.5
+        )
+        self.qkv_proj = conv_nd(1, embed_dim, 3 * embed_dim, 1)
+        self.c_proj = conv_nd(1, embed_dim, output_dim or embed_dim, 1)
+        self.num_heads = embed_dim // num_heads_channels
+        self.attention = QKVAttention(self.num_heads)
+
+    def forward(self, x):
+        b, c, *_spatial = x.shape
+        x = x.reshape(b, c, -1)  # NC(HW)
+        x = torch.cat([x.mean(dim=-1, keepdim=True), x], dim=-1)  # NC(HW+1)
+        x = x + self.positional_embedding[None, :, :].to(x.dtype)  # NC(HW+1)
+        x = self.qkv_proj(x)
+        x = self.attention(x)
+        x = self.c_proj(x)
+        return x[:, :, 0]
+
+
+class TimestepBlock(nn.Module):
+    """
+    Any module where forward() takes timestep embeddings as a second argument.
+    """
+
+    @abstractmethod
+    def forward(self, x, emb):
+        """
+        Apply the module to `x` given `emb` timestep embeddings.
+        """
+
+
+class TimestepEmbedSequential(nn.Sequential, TimestepBlock):
+    """
+    A sequential module that passes timestep embeddings to the children that
+    support it as an extra input.
+    """
+
+    def forward(self, x, emb):
+        for layer in self:
+            if isinstance(layer, TimestepBlock):
+                x = layer(x, emb)
+            else:
+                x = layer(x)
+        return x
+
+
+class Upsamplev0(nn.Module):
+    """
+    An upsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
+                 upsampling occurs in the inner-two dimensions.
+    """
+
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        if use_conv:
+            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1, bias=bias)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        if self.dims == 3:
+            x = F.interpolate(
+                x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode="nearest"
+            )
+        else:
+            x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+class Upsample(nn.Module):
+    """
+    An upsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
+                 upsampling occurs in the inner-two dimensions.
+    """
+
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True, interp_mode='nearest'):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        if interp_mode != 'nearest' :
+             self.interp_mode = interp_mode
+        if use_conv:
+            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1, bias=bias)
+    
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+
+        if hasattr(self, 'interp_mode') is False:
+            self.interp_mode = 'nearest'
+
+        if self.dims == 3:
+            x = F.interpolate(
+                x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode=self.interp_mode
+            )
+        else:
+            x = F.interpolate(x, scale_factor=2, mode=self.interp_mode)
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+
+class Downsample(nn.Module):
+    """
+    A downsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
+                 downsampling occurs in the inner-two dimensions.
+    """
+
+    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        stride = 2 if dims != 3 else (1, 2, 2)
+        if use_conv:
+            self.op = conv_nd(
+                dims, self.channels, self.out_channels, 3, stride=stride, padding=1, bias=bias
+            )
+        else:
+            assert self.channels == self.out_channels
+            self.op = avg_pool_nd(dims, kernel_size=stride, stride=stride)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        return self.op(x)
+
+
+class ResBlockNoEmb(TimestepBlock):
+    """
+    A residual block that can optionally change the number of channels.
+    :param channels: the number of input channels.
+    :param dropout: the rate of dropout.
+    :param out_channels: if specified, the number of out channels.
+    :param use_conv: if True and out_channels is specified, use a spatial
+        convolution instead of a smaller 1x1 convolution to change the
+        channels in the skip connection.
+    :param dims: determines if the signal is 1D, 2D, or 3D.
+    :param use_checkpoint: if True, use gradient checkpointing on this module.
+    :param up: if True, use this block for upsampling.
+    :param down: if True, use this block for downsampling.
+    """
+
+    def __init__(
+        self,
+        channels,
+        dropout,
+        out_channels=None,
+        use_conv=False,
+        use_scale_shift_norm=False,
+        dims=2,
+        use_checkpoint=False,
+        up=False,
+        down=False,
+        emb_off=False,
+        bias=True,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.dropout = dropout
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.use_checkpoint = use_checkpoint
+        self.use_scale_shift_norm = use_scale_shift_norm
+
+        self.in_layers = nn.Sequential(
+            normalization(channels),
+            nn.SiLU(),
+            conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias),
+        )
+
+        self.updown = up or down
+
+        if up:
+            self.h_upd = Upsample(channels, False, dims,bias=bias)
+            self.x_upd = Upsample(channels, False, dims,bias=bias)
+        elif down:
+            self.h_upd = Downsample(channels, False, dims,bias=bias)
+            self.x_upd = Downsample(channels, False, dims,bias=bias)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channels),
+            nn.SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(
+                conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1,bias=bias)
+            ),
+        )
+
+        if self.out_channels == channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = conv_nd(
+                dims, channels, self.out_channels, 3, padding=1
+            )
+        else:
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 1,bias=bias)
+
+    def forward(self, x):
+        """
+        Apply the block to a Tensor, conditioned on a timestep embedding.
+        :param x: an [N x C x ...] Tensor of features.
+        :param emb: an [N x emb_channels] Tensor of timestep embeddings.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+        return checkpoint(
+            self._forward,
+            x,
+            self.parameters(),
+            self.use_checkpoint and self.training,
+        )
+
+    def _forward(self, x):
+        if self.updown:
+            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+            h = in_rest(x)
+            h = self.h_upd(h)
+            x = self.x_upd(x)
+            h = in_conv(h)
+        else:
+            h = self.in_layers(x)
+
+        if self.use_scale_shift_norm:
+            out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+            h = out_norm(h)
+            h = out_rest(h)
+        else:
+            h = h
+            h = self.out_layers(h)
+        return self.skip_connection(x) + h
+
+
+class ResBlock(TimestepBlock):
+    """
+    A residual block that can optionally change the number of channels.
+    :param channels: the number of input channels.
+    :param emb_channels: the number of timestep embedding channels.
+    :param dropout: the rate of dropout.
+    :param out_channels: if specified, the number of out channels.
+    :param use_conv: if True and out_channels is specified, use a spatial
+        convolution instead of a smaller 1x1 convolution to change the
+        channels in the skip connection.
+    :param dims: determines if the signal is 1D, 2D, or 3D.
+    :param use_checkpoint: if True, use gradient checkpointing on this module.
+    :param up: if True, use this block for upsampling.
+    :param down: if True, use this block for downsampling.
+    """
+
+    def __init__(
+        self,
+        channels,
+        emb_channels,
+        dropout,
+        out_channels=None,
+        use_conv=False,
+        use_scale_shift_norm=False,
+        dims=2,
+        use_checkpoint=False,
+        up=False,
+        down=False,
+        emb_off=False,
+        bias=True,
+        interp_mode='nearest',
+    ):
+        super().__init__()
+        self.channels = channels
+        self.emb_channels = emb_channels
+        self.dropout = dropout
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.use_checkpoint = use_checkpoint
+        self.use_scale_shift_norm = use_scale_shift_norm
+
+        self.in_layers = nn.Sequential(
+            normalization(channels),
+            nn.SiLU(),
+            conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias),
+        )
+
+        self.updown = up or down
+
+        if up:
+            self.h_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
+            self.x_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
+        elif down:
+            self.h_upd = Downsample(channels, False, dims, bias=bias)
+            self.x_upd = Downsample(channels, False, dims, bias=bias)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        if emb_off:
+            self.emb_layers = ConstantEmbedding(
+                emb_channels,
+                2 * self.out_channels if use_scale_shift_norm else self.out_channels,
+            )
+        else:
+            self.emb_layers = nn.Sequential(
+                nn.SiLU(),
+                linear(
+                    emb_channels,
+                    2 * self.out_channels
+                    if use_scale_shift_norm
+                    else self.out_channels,
+                ),
+            )
+
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channels),
+            nn.SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(
+                conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1, bias=bias)
+            ),
+        )
+
+        if self.out_channels == channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = conv_nd(
+                dims, channels, self.out_channels, 3, padding=1, bias=bias
+            )
+        else:
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 1, bias=bias)
+
+    def forward(self, x, emb):
+        """
+        Apply the block to a Tensor, conditioned on a timestep embedding.
+        :param x: an [N x C x ...] Tensor of features.
+        :param emb: an [N x emb_channels] Tensor of timestep embeddings.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+        return checkpoint(
+            self._forward,
+            (x, emb),
+            self.parameters(),
+            self.use_checkpoint and self.training,
+        )
+
+    def _forward(self, x, emb):
+        if self.updown:
+            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+            h = in_rest(x)
+            h = self.h_upd(h)
+            x = self.x_upd(x)
+            h = in_conv(h)
+        else:
+            h = self.in_layers(x)
+        emb_out = self.emb_layers(emb).type(h.dtype)
+        while len(emb_out.shape) < len(h.shape):
+            emb_out = emb_out[..., None]
+        if self.use_scale_shift_norm:
+            out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+            scale, shift = torch.chunk(emb_out, 2, dim=1)
+            h = out_norm(h) * (1 + scale) + shift
+            h = out_rest(h)
+        else:
+            h = h + emb_out
+            h = self.out_layers(h)
+        return self.skip_connection(x) + h
+
+
+class AttentionBlock(nn.Module):
+    """
+    An attention block that allows spatial positions to attend to each other.
+    Originally ported from here, but adapted to the N-d case.
+    https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/models/unet.py#L66.
+    """
+
+    def __init__(
+        self,
+        channels,
+        num_heads=1,
+        num_head_channels=-1,
+        use_checkpoint=False,
+        use_new_attention_order=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        if num_head_channels == -1:
+            self.num_heads = num_heads
+        else:
+            assert (
+                channels % num_head_channels == 0
+            ), f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            self.num_heads = channels // num_head_channels
+        self.use_checkpoint = use_checkpoint
+        self.norm = normalization(channels)
+        self.qkv = conv_nd(1, channels, channels * 3, 1)
+        if use_new_attention_order:
+            # split qkv before split heads
+            self.attention = QKVAttention(self.num_heads)
+        else:
+            # split heads before split qkv
+            self.attention = QKVAttentionLegacy(self.num_heads)
+
+        self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
+
+    def forward(self, x):
+        return checkpoint(
+            self._forward,
+            (x,),
+            self.parameters(),
+            self.use_checkpoint and self.training,
+        )
+
+    def _forward(self, x):
+        b, c, *spatial = x.shape
+        x = x.reshape(b, c, -1)
+        qkv = self.qkv(self.norm(x))
+        h = self.attention(qkv)
+        h = self.proj_out(h)
+        return (x + h).reshape(b, c, *spatial)
+
+
+def count_flops_attn(model, _x, y):
+    """
+    A counter for the `thop` package to count the operations in an
+    attention operation.
+    Meant to be used like:
+        macs, params = thop.profile(
+            model,
+            inputs=(inputs, timestamps),
+            custom_ops={QKVAttention: QKVAttention.count_flops},
+        )
+    """
+    b, c, *spatial = y[0].shape
+    num_spatial = int(np.prod(spatial))
+    # We perform two matmuls with the same number of ops.
+    # The first computes the weight matrix, the second computes
+    # the combination of the value vectors.
+    matmul_ops = 2 * b * (num_spatial**2) * c
+    model.total_ops += torch.DoubleTensor([matmul_ops])
+
+
+class QKVAttentionLegacy(nn.Module):
+    """
+    A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (H * 3 * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts", q * scale, k * scale
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v)
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
+
+
+class QKVAttention(nn.Module):
+    """
+    A module which performs QKV attention and splits in a different order.
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (3 * H * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.chunk(3, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts",
+            (q * scale).view(bs * self.n_heads, ch, length),
+            (k * scale).view(bs * self.n_heads, ch, length),
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum(
+            "bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length)
+        )
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
 
 
 @dataclass(eq=False)
@@ -70,8 +780,6 @@ class UNetModel(nn.Module):
     ignore_time: bool = False
     input_projection: bool = True
     bias: bool = True
-    interp_mode: str = "nearest"  #  or 'bilinear'
-
     image_size: int = -1  # not used...
     _target_: str = "lib.models.gd_unet.UNetModel"
 
@@ -86,7 +794,9 @@ class UNetModel(nn.Module):
 
         self.time_embed_dim = self.model_channels * 4
         if self.ignore_time:
-            self.time_embed = lambda x: torch.zeros(x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype)
+            self.time_embed = lambda x: torch.zeros(
+                x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype
+            )
         else:
             self.time_embed = nn.Sequential(
                 linear(self.model_channels, self.time_embed_dim),
@@ -95,16 +805,26 @@ class UNetModel(nn.Module):
             )
 
         if self.num_classes is not None:
-            # print("... num_classes :", self.num_classes, flush=True)
-            self.label_emb = nn.Embedding(self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes)
+
+            print('... num_classes :',self.num_classes,flush=True)
+
+            self.label_emb = nn.Embedding(
+                self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes
+            )
 
         ch = input_ch = int(self.channel_mult[0] * self.model_channels)
         if self.input_projection:
             self.input_blocks = nn.ModuleList(
-                [TimestepEmbedSequential(conv_nd(self.dims, self.in_channels, ch, 3, padding=1))]
+                [
+                    TimestepEmbedSequential(
+                        conv_nd(self.dims, self.in_channels, ch, 3, padding=1)
+                    )
+                ]
             )
         else:
-            self.input_blocks = nn.ModuleList([TimestepEmbedSequential(torch.nn.Identity())])
+            self.input_blocks = nn.ModuleList(
+                [TimestepEmbedSequential(torch.nn.Identity())]
+            )
         self._feature_size = ch
         input_block_chans = [ch]
         ds = 1
@@ -121,11 +841,11 @@ class UNetModel(nn.Module):
                         use_scale_shift_norm=self.use_scale_shift_norm,
                         emb_off=self.ignore_time and self.num_classes is None,
                         bias=self.bias,
-                        interp_mode=self.interp_mode,
                     )
                 ]
                 ch = int(mult * self.model_channels)
 
+                print(ds)
                 if ds in self.attention_resolutions:
                     layers.append(
                         AttentionBlock(
@@ -155,7 +875,9 @@ class UNetModel(nn.Module):
                             emb_off=self.ignore_time and self.num_classes is None,
                         )
                         if self.resblock_updown
-                        else Downsample(ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias)
+                        else Downsample(
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias
+                        )
                     )
                 )
                 ch = out_ch
@@ -207,7 +929,6 @@ class UNetModel(nn.Module):
                         use_scale_shift_norm=self.use_scale_shift_norm,
                         emb_off=self.ignore_time and self.num_classes is None,
                         bias=self.bias,
-                        interp_mode=self.interp_mode,
                     )
                 ]
                 ch = int(self.model_channels * mult)
@@ -235,16 +956,10 @@ class UNetModel(nn.Module):
                             up=True,
                             emb_off=self.ignore_time and self.num_classes is None,
                             bias=self.bias,
-                            interp_mode=self.interp_mode,
                         )
                         if self.resblock_updown
                         else Upsample(
-                            ch,
-                            self.conv_resample,
-                            dims=self.dims,
-                            out_channels=out_ch,
-                            bias=self.bias,
-                            interp_mode=self.interp_mode,
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch
                         )
                     )
                     ds //= 2
@@ -257,10 +972,345 @@ class UNetModel(nn.Module):
             zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
         )
 
-    def reset_state(self, x=None):
+    def reset_state(self,x=None):
         self._grad_norm = None
 
-    def predict(self, x, timesteps, extra, hidden=None, cell=None):
+    def predict(self, x, timesteps, extra):
+        """
+        Apply the model to an input batch.
+        :param x: an [N x C x ...] Tensor of inputs.
+        :param timesteps: a 1-D batch of timesteps.
+        :param y: an [N] Tensor of labels, if class-conditional.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+        if self.with_fourier_features:
+            z_f = base2_fourier_features(x, start=6, stop=8, step=1)
+            x = torch.cat([x, z_f], dim=1)
+
+        hs = []
+
+        emb = self.time_embed(timestep_embedding(timesteps, self.model_channels).to(x))
+
+        if self.ignore_time:
+            emb = emb * 0.0
+
+        if self.num_classes and "label" not in extra:
+            # Hack to deal with ddp find_unused_parameters not working with activation checkpointing...
+            # self.num_classes corresponds to the pad index of the embedding table
+            extra["label"] = torch.full(
+                (x.size(0),), self.num_classes, dtype=torch.long, device=x.device
+            )
+
+        if self.num_classes is not None and "label" in extra:
+            y = extra["label"]
+            assert (
+                y.shape == x.shape[:1]
+            ), f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
+            emb = emb + self.label_emb(y)
+
+        h = x
+        if "concat_conditioning" in extra:
+            h = torch.cat([x, extra["concat_conditioning"]], dim=1)
+
+        for module in self.input_blocks:
+            h = module(h, emb)
+            hs.append(h)
+        h = self.middle_block(h, emb)
+        for module in self.output_blocks:
+            h = torch.cat([h, hs.pop()], dim=1)
+            h = module(h, emb)
+        h = h.type(x.dtype)
+        result = self.out(h)
+        return result
+
+    def forward(self, x, timesteps=None, extra=None):
+        #x = batch.input
+        #x = x.nan_to_num()
+
+        if ( self.dims == 3 ) and ( len(x.shape) == 4 ):
+            x = x.unsqueeze(1)  # add channel dim if missing
+
+        if timesteps is None:
+            timesteps = torch.zeros((x.shape[0],), device=x.device, dtype=torch.long)
+        if extra is None:
+            extra = []
+
+        out = self.predict(x, timesteps, extra)
+
+
+        #if self.dims+2 > len(batch.input.shape):
+        #    out = out.view(out.shape[0], out.shape[2], out.shape[3], out.shape[4] ) # add channel dim if missing
+
+        return out
+
+# Based on https://github.com/google-research/vdm/blob/main/model_vdm.py
+def base2_fourier_features(
+    inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1
+) -> torch.Tensor:
+    freqs = torch.arange(start, stop, step, device=inputs.device, dtype=inputs.dtype)
+
+    # Create Base 2 Fourier features
+    w = 2.0**freqs * 2 * np.pi
+    w = torch.tile(w[None, :], (1, inputs.size(1)))
+
+    # Compute features
+    h = torch.repeat_interleave(inputs, len(freqs), dim=1)
+    h = w[:, :, None, None] * h
+    h = torch.cat([torch.sin(h), torch.cos(h)], dim=1)
+    return h
+
+@dataclass(eq=False)
+class UNetModel2(nn.Module):
+    """
+    The full UNet model with attention and timestep embedding.
+    :param in_channels: channels in the input Tensor.
+    :param model_channels: base channel count for the model.
+    :param out_channels: channels in the output Tensor.
+    :param num_res_blocks: number of residual blocks per downsample.
+    :param attention_resolutions: a collection of downsample rates at which
+        attention will take place. May be a set, list, or tuple.
+        For example, if this contains 4, then at 4x downsampling, attention
+        will be used.
+    :param dropout: the dropout probability.
+    :param channel_mult: channel multiplier for each level of the UNet.
+    :param conv_resample: if True, use learned convolutions for upsampling and
+        downsampling.
+    :param dims: determines if the signal is 1D, 2D, or 3D.
+    :param num_classes: if specified (as an int), then this model will be
+        class-conditional with `num_classes` classes.
+    :param use_checkpoint: use gradient checkpointing to reduce memory usage.
+    :param num_heads: the number of attention heads in each attention layer.
+    :param num_heads_channels: if specified, ignore num_heads and instead use
+                               a fixed channel width per attention head.
+    :param num_heads_upsample: works with num_heads to set a different number
+                               of heads for upsampling. Deprecated.
+    :param use_scale_shift_norm: use a FiLM-like conditioning mechanism.
+    :param resblock_updown: use residual blocks for up/downsampling.
+    :param use_new_attention_order: use a different attention pattern for potentially
+                                    increased efficiency.
+    """
+
+    in_channels: int
+    model_channels: int = 128
+    out_channels: int = 3
+    num_res_blocks: int = 2
+    attention_resolutions: Tuple[int] = (1, 2, 2, 2)
+    dropout: float = 0.0
+    channel_mult: Tuple[int] = (1, 2, 4, 8)
+    conv_resample: bool = True
+    dims: int = 2
+    num_classes: Optional[int] = None
+    use_checkpoint: bool = False
+    num_heads: int = 1
+    num_head_channels: int = -1
+    num_heads_upsample: int = -1
+    use_scale_shift_norm: bool = False
+    resblock_updown: bool = False
+    use_new_attention_order: bool = False
+    with_fourier_features: bool = False
+    ignore_time: bool = False
+    input_projection: bool = True
+    bias: bool = True
+    interp_mode: str = 'nearest' #  or 'bilinear'
+
+    image_size: int = -1  # not used...
+    _target_: str = "lib.models.gd_unet.UNetModel"
+
+    def __post_init__(self):
+        super().__init__()
+
+        if self.with_fourier_features:
+            self.in_channels += 12
+
+        if self.num_heads_upsample == -1:
+            self.num_heads_upsample = self.num_heads
+
+        self.time_embed_dim = self.model_channels * 4
+        if self.ignore_time:
+            self.time_embed = lambda x: torch.zeros(
+                x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype
+            )
+        else:
+            self.time_embed = nn.Sequential(
+                linear(self.model_channels, self.time_embed_dim),
+                nn.SiLU(),
+                linear(self.time_embed_dim, self.time_embed_dim),
+            )
+
+        if self.num_classes is not None:
+
+            print('... num_classes :',self.num_classes,flush=True)
+
+            self.label_emb = nn.Embedding(
+                self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes
+            )
+
+        ch = input_ch = int(self.channel_mult[0] * self.model_channels)
+        if self.input_projection:
+            self.input_blocks = nn.ModuleList(
+                [
+                    TimestepEmbedSequential(
+                        conv_nd(self.dims, self.in_channels, ch, 3, padding=1)
+                    )
+                ]
+            )
+        else:
+            self.input_blocks = nn.ModuleList(
+                [TimestepEmbedSequential(torch.nn.Identity())]
+            )
+        self._feature_size = ch
+        input_block_chans = [ch]
+        ds = 1
+        for level, mult in enumerate(self.channel_mult):
+            for _ in range(self.num_res_blocks):
+                layers = [
+                    ResBlock(
+                        ch,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(mult * self.model_channels),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                        bias=self.bias,
+                        interp_mode=self.interp_mode
+                    )
+                ]
+                ch = int(mult * self.model_channels)
+
+                print(ds)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                self.input_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+                input_block_chans.append(ch)
+            if level != len(self.channel_mult) - 1:
+                out_ch = ch
+                self.input_blocks.append(
+                    TimestepEmbedSequential(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            down=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                        )
+                        if self.resblock_updown
+                        else Downsample(
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias
+                        )
+                    )
+                )
+                ch = out_ch
+                input_block_chans.append(ch)
+                ds *= 2
+                self._feature_size += ch
+
+        self.middle_block = TimestepEmbedSequential(
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+            AttentionBlock(
+                ch,
+                use_checkpoint=self.use_checkpoint,
+                num_heads=self.num_heads,
+                num_head_channels=self.num_head_channels,
+                use_new_attention_order=self.use_new_attention_order,
+            ),
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+        )
+        self._feature_size += ch
+
+        self.output_blocks = nn.ModuleList([])
+        for level, mult in list(enumerate(self.channel_mult))[::-1]:
+            for i in range(self.num_res_blocks + 1):
+                ich = input_block_chans.pop()
+                layers = [
+                    ResBlock(
+                        ch + ich,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(self.model_channels * mult),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                        bias=self.bias,
+                        interp_mode=self.interp_mode
+                    )
+                ]
+                ch = int(self.model_channels * mult)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads_upsample,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                if level and i == self.num_res_blocks:
+                    out_ch = ch
+                    layers.append(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            up=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                            bias=self.bias,
+                            interp_mode=self.interp_mode
+                        )
+                        if self.resblock_updown
+                        else Upsample(
+                            ch, self.conv_resample, dims=self.dims, out_channels=out_ch, bias=self.bias, interp_mode=self.interp_mode
+                        )
+                    )
+                    ds //= 2
+                self.output_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+
+        self.out = nn.Sequential(
+            normalization(ch),
+            nn.SiLU(),
+            zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
+        )
+    def reset_state(self,x=None):
+        self._grad_norm = None
+
+    def predict(self, x, timesteps, extra):
         """
         Apply the model to an input batch.
         :param x: an [N x C x ...] Tensor of inputs.
@@ -286,13 +1336,15 @@ class UNetModel(nn.Module):
         if self.num_classes and "label" not in extra:
             # Hack to deal with ddp find_unused_parameters not working with activation checkpointing...
             # self.num_classes corresponds to the pad index of the embedding table
-            extra["label"] = torch.full((x.size(0),), self.num_classes, dtype=torch.long, device=x.device)
+            extra["label"] = torch.full(
+                (x.size(0),), self.num_classes, dtype=torch.long, device=x.device
+            )
 
         if self.num_classes is not None and "label" in extra:
             y = extra["label"]
-            assert y.shape == x.shape[:1], (
-                f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
-            )
+            assert (
+                y.shape == x.shape[:1]
+            ), f"Labels have shape {y.shape}, which does not match the batch dimension of the input {x.shape}"
             emb = emb + self.label_emb(y)
 
         h = x
@@ -321,475 +1373,8 @@ class UNetModel(nn.Module):
 
         out = self.predict(x, timesteps, extra)
 
-        # if self.dims+2 > len(batch.input.shape):
+
+        #if self.dims+2 > len(batch.input.shape):
         #    out = out.view(out.shape[0], out.shape[2], out.shape[3], out.shape[4] ) # add channel dim if missing
 
         return out
-
-
-def linear(*args, **kwargs):
-    """
-    Create a linear module.
-    """
-    return nn.Linear(*args, **kwargs)
-
-
-class TimestepBlock(nn.Module):
-    """
-    Any module where forward() takes timestep embeddings as a second argument.
-    """
-
-    @abstractmethod
-    def forward(self, x, emb):
-        """
-        Apply the module to `x` given `emb` timestep embeddings.
-        """
-
-
-class TimestepEmbedSequential(nn.Sequential, TimestepBlock):
-    """
-    A sequential module that passes timestep embeddings to the children that
-    support it as an extra input.
-    """
-
-    def forward(self, x, emb):
-        for layer in self:
-            if isinstance(layer, TimestepBlock):
-                x = layer(x, emb)
-            else:
-                x = layer(x)
-        return x
-
-
-def conv_nd(dims, *args, **kwargs):
-    """
-    Create a 1D, 2D, or 3D convolution module.
-    """
-    if dims == 1:
-        return nn.Conv1d(*args, **kwargs)
-    elif dims == 2:
-        return nn.Conv2d(*args, **kwargs)
-    elif dims == 3:
-        return nn.Conv3d(*args, **kwargs)
-    raise ValueError(f"unsupported dimensions: {dims}")
-
-
-class ResBlock(TimestepBlock):
-    """
-    A residual block that can optionally change the number of channels.
-    :param channels: the number of input channels.
-    :param emb_channels: the number of timestep embedding channels.
-    :param dropout: the rate of dropout.
-    :param out_channels: if specified, the number of out channels.
-    :param use_conv: if True and out_channels is specified, use a spatial
-        convolution instead of a smaller 1x1 convolution to change the
-        channels in the skip connection.
-    :param dims: determines if the signal is 1D, 2D, or 3D.
-    :param use_checkpoint: if True, use gradient checkpointing on this module.
-    :param up: if True, use this block for upsampling.
-    :param down: if True, use this block for downsampling.
-    """
-
-    def __init__(
-        self,
-        channels,
-        emb_channels,
-        dropout,
-        out_channels=None,
-        use_conv=False,
-        use_scale_shift_norm=False,
-        dims=2,
-        use_checkpoint=False,
-        up=False,
-        down=False,
-        emb_off=False,
-        bias=True,
-        interp_mode="nearest",
-    ):
-        super().__init__()
-        self.channels = channels
-        self.emb_channels = emb_channels
-        self.dropout = dropout
-        self.out_channels = out_channels or channels
-        self.use_conv = use_conv
-        self.use_checkpoint = use_checkpoint
-        self.use_scale_shift_norm = use_scale_shift_norm
-
-        self.in_layers = nn.Sequential(
-            normalization(channels),
-            nn.SiLU(),
-            conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias),
-        )
-
-        self.updown = up or down
-
-        if up:
-            self.h_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
-            self.x_upd = Upsample(channels, False, dims, bias=bias, interp_mode=interp_mode)
-        elif down:
-            self.h_upd = Downsample(channels, False, dims, bias=bias)
-            self.x_upd = Downsample(channels, False, dims, bias=bias)
-        else:
-            self.h_upd = self.x_upd = nn.Identity()
-
-        if emb_off:
-            self.emb_layers = ConstantEmbedding(
-                emb_channels,
-                2 * self.out_channels if use_scale_shift_norm else self.out_channels,
-            )
-        else:
-            self.emb_layers = nn.Sequential(
-                nn.SiLU(),
-                linear(
-                    emb_channels,
-                    2 * self.out_channels if use_scale_shift_norm else self.out_channels,
-                ),
-            )
-
-        self.out_layers = nn.Sequential(
-            normalization(self.out_channels),
-            nn.SiLU(),
-            nn.Dropout(p=dropout),
-            zero_module(conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1, bias=bias)),
-        )
-
-        if self.out_channels == channels:
-            self.skip_connection = nn.Identity()
-        elif use_conv:
-            self.skip_connection = conv_nd(dims, channels, self.out_channels, 3, padding=1, bias=bias)
-        else:
-            self.skip_connection = conv_nd(dims, channels, self.out_channels, 1, bias=bias)
-
-    def forward(self, x, emb):
-        """
-        Apply the block to a Tensor, conditioned on a timestep embedding.
-        :param x: an [N x C x ...] Tensor of features.
-        :param emb: an [N x emb_channels] Tensor of timestep embeddings.
-        :return: an [N x C x ...] Tensor of outputs.
-        """
-        return checkpoint(
-            self._forward,
-            (x, emb),
-            self.parameters(),
-            self.use_checkpoint and self.training,
-        )
-
-    def _forward(self, x, emb):
-        if self.updown:
-            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
-            h = in_rest(x)
-            h = self.h_upd(h)
-            x = self.x_upd(x)
-            h = in_conv(h)
-        else:
-            h = self.in_layers(x)
-        emb_out = self.emb_layers(emb).type(h.dtype)
-        while len(emb_out.shape) < len(h.shape):
-            emb_out = emb_out[..., None]
-        if self.use_scale_shift_norm:
-            out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
-            scale, shift = torch.chunk(emb_out, 2, dim=1)
-            h = out_norm(h) * (1 + scale) + shift
-            h = out_rest(h)
-        else:
-            h = h + emb_out
-            h = self.out_layers(h)
-        return self.skip_connection(x) + h
-
-
-def normalization(channels):
-    """
-    Make a standard normalization layer.
-    :param channels: number of input channels.
-    :return: an nn.Module for normalization.
-    """
-    return GroupNorm32(32, channels)
-
-
-class GroupNorm32(nn.GroupNorm):
-    def forward(self, x):
-        return super().forward(x.float()).type(x.dtype)
-
-
-class Upsample(nn.Module):
-    """
-    An upsampling layer with an optional convolution.
-    :param channels: channels in the inputs and outputs.
-    :param use_conv: a bool determining if a convolution is applied.
-    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
-                 upsampling occurs in the inner-two dimensions.
-    """
-
-    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True, interp_mode="nearest"):
-        super().__init__()
-        self.channels = channels
-        self.out_channels = out_channels or channels
-        self.use_conv = use_conv
-        self.dims = dims
-        if interp_mode != "nearest":
-            self.interp_mode = interp_mode
-        if use_conv:
-            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1, bias=bias)
-
-    def forward(self, x):
-        assert x.shape[1] == self.channels
-
-        if hasattr(self, "interp_mode") is False:
-            self.interp_mode = "nearest"
-
-        if self.dims == 3:
-            x = F.interpolate(x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode=self.interp_mode)
-        else:
-            x = F.interpolate(x, scale_factor=2, mode=self.interp_mode)
-        if self.use_conv:
-            x = self.conv(x)
-        return x
-
-
-class Downsample(nn.Module):
-    """
-    A downsampling layer with an optional convolution.
-    :param channels: channels in the inputs and outputs.
-    :param use_conv: a bool determining if a convolution is applied.
-    :param dims: determines if the signal is 1D, 2D, or 3D. If 3D, then
-                 downsampling occurs in the inner-two dimensions.
-    """
-
-    def __init__(self, channels, use_conv, dims=2, out_channels=None, bias=True):
-        super().__init__()
-        self.channels = channels
-        self.out_channels = out_channels or channels
-        self.use_conv = use_conv
-        self.dims = dims
-        stride = 2 if dims != 3 else (1, 2, 2)
-        if use_conv:
-            self.op = conv_nd(dims, self.channels, self.out_channels, 3, stride=stride, padding=1, bias=bias)
-        else:
-            assert self.channels == self.out_channels
-            self.op = avg_pool_nd(dims, kernel_size=stride, stride=stride)
-
-    def forward(self, x):
-        assert x.shape[1] == self.channels
-        return self.op(x)
-
-
-class ConstantEmbedding(nn.Module):
-    def __init__(self, in_channels, out_channels):
-        super().__init__()
-        self.embedding_table = nn.Parameter(torch.empty((1, out_channels)))
-        nn.init.uniform_(self.embedding_table, -(in_channels**0.5), in_channels**0.5)
-
-    def forward(self, emb):
-        return self.embedding_table.repeat(emb.shape[0], 1)
-
-
-def zero_module(module):
-    """
-    Zero out the parameters of a module and return it.
-    """
-    for p in module.parameters():
-        p.detach().zero_()
-    return module
-
-
-def checkpoint(func, inputs, params, flag):
-    """
-    Evaluate a function without caching intermediate activations, allowing for
-    reduced memory at the expense of extra compute in the backward pass.
-    :param func: the function to evaluate.
-    :param inputs: the argument sequence to pass to `func`.
-    :param params: a sequence of parameters `func` depends on but does not
-                   explicitly take as arguments.
-    :param flag: if False, disable gradient checkpointing.
-    """
-    if flag:
-        # Use pytorch's activation checkpointing.  This has support for fp16 autocast
-        return torch.utils.checkpoint.checkpoint(func, *inputs)
-        # args = tuple(inputs) + tuple(params)
-        # return CheckpointFunction.apply(func, len(inputs), *args)
-    else:
-        return func(*inputs)
-
-
-def avg_pool_nd(dims, *args, **kwargs):
-    """
-    Create a 1D, 2D, or 3D average pooling module.
-    """
-    if dims == 1:
-        return nn.AvgPool1d(*args, **kwargs)
-    elif dims == 2:
-        return nn.AvgPool2d(*args, **kwargs)
-    elif dims == 3:
-        return nn.AvgPool3d(*args, **kwargs)
-    raise ValueError(f"unsupported dimensions: {dims}")
-
-
-class AttentionBlock(nn.Module):
-    """
-    An attention block that allows spatial positions to attend to each other.
-    Originally ported from here, but adapted to the N-d case.
-    https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/models/unet.py#L66.
-    """
-
-    def __init__(
-        self,
-        channels,
-        num_heads=1,
-        num_head_channels=-1,
-        use_checkpoint=False,
-        use_new_attention_order=False,
-    ):
-        super().__init__()
-        self.channels = channels
-        if num_head_channels == -1:
-            self.num_heads = num_heads
-        else:
-            assert channels % num_head_channels == 0, (
-                f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
-            )
-            self.num_heads = channels // num_head_channels
-        self.use_checkpoint = use_checkpoint
-        self.norm = normalization(channels)
-        self.qkv = conv_nd(1, channels, channels * 3, 1)
-        if use_new_attention_order:
-            # split qkv before split heads
-            self.attention = QKVAttention(self.num_heads)
-        else:
-            # split heads before split qkv
-            self.attention = QKVAttentionLegacy(self.num_heads)
-
-        self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
-
-    def forward(self, x):
-        return checkpoint(
-            self._forward,
-            (x,),
-            self.parameters(),
-            self.use_checkpoint and self.training,
-        )
-
-    def _forward(self, x):
-        b, c, *spatial = x.shape
-        x = x.reshape(b, c, -1)
-        qkv = self.qkv(self.norm(x))
-        h = self.attention(qkv)
-        h = self.proj_out(h)
-        return (x + h).reshape(b, c, *spatial)
-
-
-class QKVAttentionLegacy(nn.Module):
-    """
-    A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
-    """
-
-    def __init__(self, n_heads):
-        super().__init__()
-        self.n_heads = n_heads
-
-    def forward(self, qkv):
-        """
-        Apply QKV attention.
-        :param qkv: an [N x (H * 3 * C) x T] tensor of Qs, Ks, and Vs.
-        :return: an [N x (H * C) x T] tensor after attention.
-        """
-        bs, width, length = qkv.shape
-        assert width % (3 * self.n_heads) == 0
-        ch = width // (3 * self.n_heads)
-        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
-        scale = 1 / math.sqrt(math.sqrt(ch))
-        weight = torch.einsum("bct,bcs->bts", q * scale, k * scale)  # More stable with f16 than dividing afterwards
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        a = torch.einsum("bts,bcs->bct", weight, v)
-        return a.reshape(bs, -1, length)
-
-    @staticmethod
-    def count_flops(model, _x, y):
-        return count_flops_attn(model, _x, y)
-
-
-class QKVAttention(nn.Module):
-    """
-    A module which performs QKV attention and splits in a different order.
-    """
-
-    def __init__(self, n_heads):
-        super().__init__()
-        self.n_heads = n_heads
-
-    def forward(self, qkv):
-        """
-        Apply QKV attention.
-        :param qkv: an [N x (3 * H * C) x T] tensor of Qs, Ks, and Vs.
-        :return: an [N x (H * C) x T] tensor after attention.
-        """
-        bs, width, length = qkv.shape
-        assert width % (3 * self.n_heads) == 0
-        ch = width // (3 * self.n_heads)
-        q, k, v = qkv.chunk(3, dim=1)
-        scale = 1 / math.sqrt(math.sqrt(ch))
-        weight = torch.einsum(
-            "bct,bcs->bts",
-            (q * scale).view(bs * self.n_heads, ch, length),
-            (k * scale).view(bs * self.n_heads, ch, length),
-        )  # More stable with f16 than dividing afterwards
-        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
-        a = torch.einsum("bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length))
-        return a.reshape(bs, -1, length)
-
-    @staticmethod
-    def count_flops(model, _x, y):
-        return count_flops_attn(model, _x, y)
-
-
-def count_flops_attn(model, _x, y):
-    """
-    A counter for the `thop` package to count the operations in an
-    attention operation.
-    Meant to be used like:
-        macs, params = thop.profile(
-            model,
-            inputs=(inputs, timestamps),
-            custom_ops={QKVAttention: QKVAttention.count_flops},
-        )
-    """
-    b, c, *spatial = y[0].shape
-    num_spatial = int(np.prod(spatial))
-    # We perform two matmuls with the same number of ops.
-    # The first computes the weight matrix, the second computes
-    # the combination of the value vectors.
-    matmul_ops = 2 * b * (num_spatial**2) * c
-    model.total_ops += torch.DoubleTensor([matmul_ops])
-
-
-def base2_fourier_features(inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1) -> torch.Tensor:
-    freqs = torch.arange(start, stop, step, device=inputs.device, dtype=inputs.dtype)
-
-    # Create Base 2 Fourier features
-    w = 2.0**freqs * 2 * np.pi
-    w = torch.tile(w[None, :], (1, inputs.size(1)))
-
-    # Compute features
-    h = torch.repeat_interleave(inputs, len(freqs), dim=1)
-    h = w[:, :, None, None] * h
-    h = torch.cat([torch.sin(h), torch.cos(h)], dim=1)
-    return h
-
-
-def timestep_embedding(timesteps, dim, max_period=10000):
-    """
-    Create sinusoidal timestep embeddings.
-    :param timesteps: a 1-D Tensor of N indices, one per batch element.
-                      These may be fractional.
-    :param dim: the dimension of the output.
-    :param max_period: controls the minimum frequency of the embeddings.
-    :return: an [N x dim] Tensor of positional embeddings.
-    """
-    half = dim // 2
-    freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half).to(
-        device=timesteps.device
-    )
-    args = timesteps[:, None].float() * freqs[None]
-    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
-    if dim % 2:
-        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
-    return embedding

--- a/ocean4dvarnet/utils.py
+++ b/ocean4dvarnet/utils.py
@@ -32,9 +32,6 @@ Functions:
     best_ckpt: Retrieve the best checkpoint from an experiment directory.
     load_cfg: Load configuration files for an experiment.
 """
-
-
-
 from pathlib import Path
 from omegaconf import OmegaConf
 import numpy as np
@@ -45,6 +42,7 @@ import xrft
 import torch
 import xarray as xr
 import matplotlib.pyplot as plt
+
 
 def pipe(inp, fns):
     """
@@ -109,6 +107,7 @@ def half_lr_adam(lit_mod, lr):
         ],
     )
 
+
 def cosanneal_lr_adam_base(lit_mod, lr, T_max=100, weight_decay=0.):
     """
     Configure an Adam optimizer with cosine annealing learning rate scheduling.
@@ -133,6 +132,7 @@ def cosanneal_lr_adam_base(lit_mod, lr, T_max=100, weight_decay=0.):
             opt, T_max=T_max
         ),
     }
+
 
 def cosanneal_lr_adam(lit_mod, lr, T_max=100, weight_decay=0.):
     """
@@ -690,15 +690,22 @@ def load_cfg(xp_dir):
     return cfg, OmegaConf.select(hydra_cfg, "runtime.choices.xp")
 
 
-
 def load_sea_level_anomaly(tgt_path, inp_path, tgt_var="sla", inp_var="sla"):
-    isel = None
+    def rename_coords(ds):
+        rename = dict()
 
-    tgt = (
-        xr.open_dataset(tgt_path)[tgt_var]
-        .isel(isel)
+        if 'latitude' in ds.coords and 'lat' not in ds.coords:
+            rename['latitude'] = 'lat'
+        if 'longitude' in ds.coords and 'lon' not in ds.coords:
+            rename['longitude'] = 'lon'
+
+        return ds.rename(rename)
+
+    tgt = rename_coords(
+        xr.open_dataset(tgt_path)
         .rename(latitude="lat", longitude="lon")
-    )
-    inp = xr.open_dataset(inp_path)[inp_var].isel(isel)
+    )[tgt_var]
+
+    inp = rename_coords(xr.open_dataset(inp_path))[inp_var]
 
     return {"input": inp, "tgt": tgt}

--- a/ocean4dvarnet/utils.py
+++ b/ocean4dvarnet/utils.py
@@ -688,3 +688,17 @@ def load_cfg(xp_dir):
         return None, None
 
     return cfg, OmegaConf.select(hydra_cfg, "runtime.choices.xp")
+
+
+
+def load_sea_level_anomaly(tgt_path, inp_path, tgt_var="sla", inp_var="sla"):
+    isel = None
+
+    tgt = (
+        xr.open_dataset(tgt_path)[tgt_var]
+        .isel(isel)
+        .rename(latitude="lat", longitude="lon")
+    )
+    inp = xr.open_dataset(inp_path)[inp_var].isel(isel)
+
+    return {"input": inp, "tgt": tgt}


### PR DESCRIPTION
This pull request addresses two issues:
- sometimes, the training dataset can be heavy, which would cause an important loading time at the beginning of an experiment and require important CPU RAM;
- the patch's dimensions and strides must currently satisfy $\text{stride} | \text{domaine size} - \text{patch size}$, so the source domain is fully covered (spatially) by the sampling. If this criterion is not respected, patches sampled at the edge of the source domain can be smaller (than a patch sampled in the middle of the domain). This severely constraint the patch's dimensions and strides. 

This pull request introduces two classes `LazyDataModule` and `LazyXrDataset` (to be used instead of `BaseDataModule` and `XrDataset`) to solve these issues.

TODO: submit a documentation on how to use it